### PR TITLE
Add remote marketplace integration with caching

### DIFF
--- a/src/cachibot/api/routes/marketplace.py
+++ b/src/cachibot/api/routes/marketplace.py
@@ -1,7 +1,13 @@
-"""Marketplace API Routes for bot templates."""
+"""Marketplace API Routes for bot templates.
 
+Supports both local templates and remote fetch from cachibot.com marketplace.
+Remote templates are cached for 5 minutes to reduce API calls.
+"""
+
+import logging
+import os
+import time
 from datetime import datetime
-from typing import Literal
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -16,12 +22,20 @@ from cachibot.data.marketplace_templates import (
     get_templates_by_category,
     get_template_by_id,
     search_templates,
-    TemplateCategory,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/marketplace", tags=["marketplace"])
 
 repo = BotRepository()
+
+# Remote marketplace configuration
+MARKETPLACE_URL = os.getenv("CACHIBOT_MARKETPLACE_URL", "")
+CACHE_TTL_SECONDS = 300  # 5 minutes
+
+# In-memory cache for remote templates
+_remote_cache: dict[str, tuple[float, list | dict]] = {}
 
 
 class TemplateResponse(BaseModel):
@@ -46,6 +60,7 @@ class TemplateListResponse(BaseModel):
 
     templates: list[TemplateResponse]
     total: int
+    source: str = "local"  # "local" or "remote"
 
 
 class CategoryInfo(BaseModel):
@@ -66,19 +81,19 @@ class InstallResponse(BaseModel):
     message: str
 
 
-# Category metadata
+# Category metadata (used when remote is unavailable)
 CATEGORY_INFO: dict[str, CategoryInfo] = {
     "productivity": CategoryInfo(
         id="productivity",
         name="Productivity",
         description="Tools for getting things done efficiently",
-        count=3,
+        count=4,
     ),
     "coding": CategoryInfo(
         id="coding",
         name="Coding & Development",
         description="Programming assistants and code tools",
-        count=3,
+        count=4,
     ),
     "creative": CategoryInfo(
         id="creative",
@@ -104,7 +119,137 @@ CATEGORY_INFO: dict[str, CategoryInfo] = {
         description="Tech support and troubleshooting",
         count=1,
     ),
+    "research": CategoryInfo(
+        id="research",
+        name="Research",
+        description="Research, analysis, and knowledge gathering",
+        count=1,
+    ),
 }
+
+
+def _get_cached(key: str) -> list | dict | None:
+    """Get cached data if still valid."""
+    if key in _remote_cache:
+        timestamp, data = _remote_cache[key]
+        if time.time() - timestamp < CACHE_TTL_SECONDS:
+            return data
+        del _remote_cache[key]
+    return None
+
+
+def _set_cache(key: str, data: list | dict) -> None:
+    """Cache data with current timestamp."""
+    _remote_cache[key] = (time.time(), data)
+
+
+async def _fetch_remote_templates(
+    category: str | None = None,
+    search: str | None = None,
+) -> TemplateListResponse | None:
+    """
+    Fetch templates from remote marketplace API.
+
+    Returns None if remote fetch fails or is not configured.
+    """
+    if not MARKETPLACE_URL:
+        return None
+
+    try:
+        import httpx
+
+        cache_key = f"templates:{category or ''}:{search or ''}"
+        cached = _get_cached(cache_key)
+        if cached:
+            templates = [TemplateResponse(**t) for t in cached]  # type: ignore
+            return TemplateListResponse(
+                templates=templates,
+                total=len(templates),
+                source="remote",
+            )
+
+        # Build URL with query params
+        url = f"{MARKETPLACE_URL.rstrip('/')}/api/v1/templates"
+        params = {}
+        if category:
+            params["category"] = category
+        if search:
+            params["search"] = search
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+        # Cache the raw template data
+        _set_cache(cache_key, data.get("templates", []))
+
+        templates = [TemplateResponse(**t) for t in data.get("templates", [])]
+        return TemplateListResponse(
+            templates=templates,
+            total=len(templates),
+            source="remote",
+        )
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch remote templates: {e}")
+        return None
+
+
+async def _fetch_remote_template(template_id: str) -> TemplateResponse | None:
+    """Fetch a single template from remote marketplace."""
+    if not MARKETPLACE_URL:
+        return None
+
+    try:
+        import httpx
+
+        cache_key = f"template:{template_id}"
+        cached = _get_cached(cache_key)
+        if cached:
+            return TemplateResponse(**cached)  # type: ignore
+
+        url = f"{MARKETPLACE_URL.rstrip('/')}/api/v1/templates/{template_id}"
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+        _set_cache(cache_key, data)
+        return TemplateResponse(**data)
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch remote template {template_id}: {e}")
+        return None
+
+
+async def _fetch_remote_categories() -> list[CategoryInfo] | None:
+    """Fetch categories from remote marketplace."""
+    if not MARKETPLACE_URL:
+        return None
+
+    try:
+        import httpx
+
+        cache_key = "categories"
+        cached = _get_cached(cache_key)
+        if cached:
+            return [CategoryInfo(**c) for c in cached]  # type: ignore
+
+        url = f"{MARKETPLACE_URL.rstrip('/')}/api/v1/categories"
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+        _set_cache(cache_key, data)
+        return [CategoryInfo(**c) for c in data]
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch remote categories: {e}")
+        return None
 
 
 @router.get("/templates", response_model=TemplateListResponse)
@@ -116,8 +261,15 @@ async def list_templates(
     """
     List all available marketplace templates.
 
-    Optionally filter by category or search query.
+    If CACHIBOT_MARKETPLACE_URL is configured, attempts to fetch from remote.
+    Falls back to local templates if remote is unavailable.
     """
+    # Try remote first if configured
+    remote_result = await _fetch_remote_templates(category, search)
+    if remote_result:
+        return remote_result
+
+    # Fall back to local templates
     if search:
         templates = search_templates(search)
     elif category:
@@ -128,6 +280,7 @@ async def list_templates(
     return TemplateListResponse(
         templates=[TemplateResponse(**t) for t in templates],
         total=len(templates),
+        source="local",
     )
 
 
@@ -137,6 +290,12 @@ async def get_template(
     user: User = Depends(get_current_user),
 ) -> TemplateResponse:
     """Get details of a specific template."""
+    # Try remote first if configured
+    remote_template = await _fetch_remote_template(template_id)
+    if remote_template:
+        return remote_template
+
+    # Fall back to local
     template = get_template_by_id(template_id)
     if template is None:
         raise HTTPException(status_code=404, detail="Template not found")
@@ -152,9 +311,22 @@ async def install_template(
     Install a template to create a new bot.
 
     Creates a new bot with the template's configuration.
+    Tries remote marketplace first, falls back to local templates.
     """
-    template = get_template_by_id(template_id)
-    if template is None:
+    # Try to get template from remote or local
+    template_data = None
+
+    # Check remote first
+    remote_template = await _fetch_remote_template(template_id)
+    if remote_template:
+        template_data = remote_template.model_dump()
+    else:
+        # Fall back to local
+        local_template = get_template_by_id(template_id)
+        if local_template:
+            template_data = local_template
+
+    if template_data is None:
         raise HTTPException(status_code=404, detail="Template not found")
 
     # Generate new bot ID
@@ -164,13 +336,13 @@ async def install_template(
     # Create the bot from template
     bot = Bot(
         id=bot_id,
-        name=template["name"],
-        description=template["description"],
-        icon=template["icon"],
-        color=template["color"],
-        model=template["model"],
-        systemPrompt=template["system_prompt"],
-        capabilities={tool: True for tool in template["tools"]},
+        name=template_data["name"],
+        description=template_data["description"],
+        icon=template_data["icon"],
+        color=template_data["color"],
+        model=template_data["model"],
+        systemPrompt=template_data["system_prompt"],
+        capabilities={tool: True for tool in template_data["tools"]},
         createdAt=now,
         updatedAt=now,
     )
@@ -179,9 +351,9 @@ async def install_template(
 
     return InstallResponse(
         bot_id=bot_id,
-        name=template["name"],
+        name=template_data["name"],
         installed=True,
-        message=f"Successfully installed '{template['name']}' template",
+        message=f"Successfully installed '{template_data['name']}' template",
     )
 
 
@@ -190,4 +362,10 @@ async def list_categories(
     user: User = Depends(get_current_user),
 ) -> list[CategoryInfo]:
     """List all template categories with counts."""
+    # Try remote first if configured
+    remote_categories = await _fetch_remote_categories()
+    if remote_categories:
+        return remote_categories
+
+    # Fall back to local
     return list(CATEGORY_INFO.values())

--- a/src/cachibot/data/marketplace_templates.py
+++ b/src/cachibot/data/marketplace_templates.py
@@ -10,6 +10,7 @@ TemplateCategory = Literal[
     "data",
     "learning",
     "support",
+    "research",
 ]
 
 
@@ -133,6 +134,41 @@ Be supportive but practical. Help users make progress, not perfect plans.""",
             "tools": ["file_read", "file_write"],
             "rating": 4.5,
             "downloads": 8200,
+        },
+        {
+            "id": "file-organizer",
+            "name": "File Organizer",
+            "description": "Automatically organize files by type, date, or custom rules",
+            "icon": "folder",
+            "color": "#3b82f6",
+            "category": "productivity",
+            "tags": ["files", "automation", "cleanup", "organization"],
+            "model": "moonshot/kimi-k2.5",
+            "system_prompt": """You are a File Organization Assistant, helping keep workspaces tidy and efficient.
+
+## Your Capabilities
+- Analyze file structures and suggest organization
+- Create folder hierarchies based on content
+- Move and rename files based on patterns
+- Clean up duplicates and temporary files
+- Set up organizational systems
+
+## Organization Strategies
+- **By Type**: Documents, Images, Code, Data
+- **By Date**: Year/Month folders, archive old files
+- **By Project**: Group related files together
+- **Custom Rules**: Based on naming patterns or content
+
+## Best Practices
+- Always confirm before moving files
+- Suggest backup before major reorganization
+- Create clear, consistent naming conventions
+- Consider search-ability when organizing
+
+I'll help you find what you need, when you need it.""",
+            "tools": ["file_list", "file_read", "file_write", "python_execute"],
+            "rating": 4.4,
+            "downloads": 5600,
         },
     ],
     "coding": [
@@ -638,6 +674,45 @@ I'm patient and here to help. No question is too basic!""",
             "tools": ["file_read", "shell_run"],
             "rating": 4.6,
             "downloads": 5400,
+        },
+    ],
+    "research": [
+        {
+            "id": "research-assistant",
+            "name": "Research Assistant",
+            "description": "Summarize documents, extract key points, and organize research notes",
+            "icon": "microscope",
+            "color": "#f59e0b",
+            "category": "research",
+            "tags": ["research", "notes", "summary", "analysis"],
+            "model": "moonshot/kimi-k2.5",
+            "system_prompt": """You are a Research Assistant, helping organize and synthesize information.
+
+## Research Capabilities
+- Summarize documents and articles
+- Extract key findings and quotes
+- Organize notes by theme
+- Create annotated bibliographies
+- Identify gaps in research
+
+## My Process
+1. **Understand**: What's the research question?
+2. **Gather**: Collect and organize sources
+3. **Analyze**: Extract relevant information
+4. **Synthesize**: Find patterns and connections
+5. **Present**: Clear, organized output
+
+## Output Formats
+- Executive summaries
+- Bullet-point key findings
+- Thematic analysis
+- Comparison tables
+- Research outlines
+
+Let me help you make sense of complex information.""",
+            "tools": ["file_read", "file_write", "python_execute"],
+            "rating": 4.6,
+            "downloads": 7800,
         },
     ],
 }


### PR DESCRIPTION
Enable optional remote marketplace support with local caching and fallback to local templates.

- frontend: add VITE_MARKETPLACE_URL support, client-side localStorage cache (5 min TTL), remote fetch helpers (templates, single template, categories), mark responses with source ('remote'|'local'), and try remote first with fallback to local API; install still uses local API.
- backend: add CACHIBOT_MARKETPLACE_URL env var, in-memory cache (5 min TTL), async httpx fetch helpers for remote templates/template/categories, and attempt remote fetch before falling back to local data in endpoints; update category counts.
- data: add new "research" category and two templates (file-organizer, research-assistant) and update template/category metadata.

This improves UX by surfacing remote marketplace content when configured while preserving offline/local behavior and reducing remote calls via caching.