### PR TITLE
Build frontend in CI and bundle dist in wheel

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -67,6 +67,16 @@ jobs:
           git tag -a "${{ steps.ver.outputs.tag }}" -m "pre: ${{ steps.ver.outputs.new }}"
           git push origin "${{ steps.ver.outputs.tag }}"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with: { python-version: '3.x' }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,16 @@ jobs:
           git tag --list
           git describe --tags --long || true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with: { python-version: '3.x' }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ Documentation = "https://cachibot.dev/docs"
 Repository = "https://github.com/jhd3197/cachibot"
 Issues = "https://github.com/jhd3197/cachibot/issues"
 
+[tool.hatch.build.targets.sdist.force-include]
+"frontend/dist" = "frontend/dist"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/cachibot"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ Issues = "https://github.com/jhd3197/cachibot/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/cachibot"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"frontend/dist" = "cachibot/frontend_dist"
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100

--- a/src/cachibot/api/server.py
+++ b/src/cachibot/api/server.py
@@ -36,8 +36,14 @@ from cachibot.services.platform_manager import get_platform_manager
 from cachibot.storage.database import close_db, init_db
 
 # Find the frontend dist directory
-PACKAGE_DIR = Path(__file__).parent.parent.parent.parent
-FRONTEND_DIST = PACKAGE_DIR / "frontend" / "dist"
+# 1. Bundled in the package (pip install case): cachibot/frontend_dist/
+_BUNDLED_DIST = Path(__file__).parent.parent / "frontend_dist"
+# 2. Development repo (editable install / local dev): repo_root/frontend/dist/
+_DEV_DIST = Path(__file__).parent.parent.parent.parent / "frontend" / "dist"
+
+FRONTEND_DIST = (
+    _BUNDLED_DIST if (_BUNDLED_DIST / "index.html").exists() else _DEV_DIST
+)
 
 
 @asynccontextmanager
@@ -149,7 +155,6 @@ def create_app(
                 "version": "0.2.0",
                 "docs": "/docs",
                 "health": "/api/health",
-                "note": "Frontend not built. Run 'npm run build' in frontend/ directory.",
             }
 
     return app


### PR DESCRIPTION
Add Node.js setup and frontend build steps to dev and publish GitHub Actions (uses Node 20, npm ci + npm run build) so the frontend is built during CI. Include frontend/dist in the Python wheel by adding a force-include mapping (frontend/dist -> cachibot/frontend_dist) in pyproject.toml. Update the server to resolve the frontend distribution path at runtime: prefer the bundled cachibot/frontend_dist (installed via wheel) and fall back to the repository frontend/dist for local development. This ensures the packaged app can serve static assets after pip install and CI produces the built frontend artifacts.