### PR TITLE
Add VERSION support and extended health info

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -86,9 +86,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools_scm build twine
 
-      - name: Set version in pyproject.toml
+      - name: Set version in pyproject.toml and VERSION file
         run: |
           sed -i 's/^version = ".*"/version = "${{ steps.ver.outputs.new }}"/' pyproject.toml
+          echo "${{ steps.ver.outputs.new }}" > VERSION
           grep '^version' pyproject.toml
 
       - name: Build (dev)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,6 +138,7 @@ jobs:
       - name: Set version in pyproject.toml
         run: |
           sed -i 's/^version = ".*"/version = "${{ steps.bump_version.outputs.new_version }}"/' pyproject.toml
+          echo "${{ steps.bump_version.outputs.new_version }}" > VERSION
           grep '^version' pyproject.toml
 
       - name: Build (release)

--- a/README.md
+++ b/README.md
@@ -54,17 +54,10 @@ Most AI agent tools run in terminals where you can't see what's happening. That'
 
 ## Quick Start
 
-### 1. Clone and Install
+### 1. Install
 
 ```bash
-git clone https://github.com/jhd3197/CachiBot.git
-cd CachiBot
-
-# Install backend
-pip install -e ".[dev]"
-
-# Install frontend
-cd frontend && npm install
+pip install cachibot
 ```
 
 ### 2. Set your API key
@@ -83,14 +76,29 @@ export OPENAI_API_KEY="your-api-key"
 ### 3. Run CachiBot
 
 ```bash
-# Terminal 1: Start the backend server
-cachibot-server
-
-# Terminal 2: Start the frontend
-cd frontend && npm run dev
+cachibot server
 ```
 
-Open **http://localhost:5173** in your browser.
+Open **http://localhost:6392** in your browser. The frontend is bundled and served automatically.
+
+### CLI Usage
+
+```bash
+# Start the dashboard server
+cachibot server
+
+# Run a single task
+cachibot "list all Python files"
+
+# Interactive mode
+cachibot
+
+# Use a specific model
+cachibot --model anthropic/claude-sonnet-4-20250514 "explain this code"
+
+# Short alias works too
+cachi server
+```
 
 ## Architecture
 
@@ -183,6 +191,12 @@ pip install -e ".[dev]"
 
 # Install frontend dependencies
 cd frontend && npm install
+
+# Start backend (dev)
+cachibot server --reload
+
+# Start frontend dev server (in another terminal)
+cd frontend && npm run dev
 
 # Run tests
 pytest

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -64,7 +64,15 @@ async function request<T>(
 }
 
 // Health check
-export async function checkHealth(): Promise<{ status: string; version: string }> {
+export interface HealthInfo {
+  status: string
+  version: string
+  build: string
+  python: string
+  platform: string
+}
+
+export async function checkHealth(): Promise<HealthInfo> {
   return request('/health')
 }
 

--- a/frontend/src/components/views/AppSettingsView.tsx
+++ b/frontend/src/components/views/AppSettingsView.tsx
@@ -47,6 +47,7 @@ import { useAuthStore } from '../../stores/auth'
 import { useBotStore, useChatStore, useJobStore, useTaskStore } from '../../stores/bots'
 import { useConnectionStore, useUsageStore } from '../../stores/connections'
 import { listUsers, createUser, updateUser, deactivateUser } from '../../api/auth'
+import { checkHealth, type HealthInfo } from '../../api/client'
 import { ModelSelect } from '../common/ModelSelect'
 import { Button } from '../common/Button'
 import { cn } from '../../lib/utils'
@@ -75,6 +76,14 @@ export function AppSettingsView() {
   const { user: currentUser } = useAuthStore()
 
   const isAdmin = currentUser?.role === 'admin'
+
+  const [healthInfo, setHealthInfo] = useState<HealthInfo | null>(null)
+
+  useEffect(() => {
+    checkHealth()
+      .then(setHealthInfo)
+      .catch(() => {})
+  }, [])
 
   // Determine active tab from URL, with validation
   const getActiveTab = (): SettingsTab => {
@@ -149,6 +158,7 @@ export function AppSettingsView() {
                 showCost={showCost}
                 setShowCost={setShowCost}
                 config={config}
+                healthInfo={healthInfo}
               />
             )}
             {activeTab === 'appearance' && (
@@ -182,12 +192,14 @@ function GeneralSettings({
   showCost,
   setShowCost,
   config,
+  healthInfo,
 }: {
   showThinking: boolean
   setShowThinking: (show: boolean) => void
   showCost: boolean
   setShowCost: (show: boolean) => void
   config: Config | null
+  healthInfo: HealthInfo | null
 }) {
   return (
     <>
@@ -243,6 +255,47 @@ function GeneralSettings({
               Directory where bots can read and write files
             </p>
           </Field>
+        </div>
+      </Section>
+
+      <Section icon={Info} title="About">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-zinc-500 dark:text-zinc-400">Version</span>
+            <span className="font-mono text-zinc-800 dark:text-zinc-200">
+              {healthInfo?.version ?? '...'}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-zinc-500 dark:text-zinc-400">Build</span>
+            <span className="font-mono text-zinc-800 dark:text-zinc-200">
+              {healthInfo?.build ?? '...'}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-zinc-500 dark:text-zinc-400">Python</span>
+            <span className="font-mono text-zinc-800 dark:text-zinc-200">
+              {healthInfo?.python ?? '...'}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-zinc-500 dark:text-zinc-400">Platform</span>
+            <span className="font-mono text-zinc-800 dark:text-zinc-200">
+              {healthInfo?.platform ?? '...'}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-zinc-500 dark:text-zinc-400">Documentation</span>
+            <a
+              href="https://github.com/jhd3197/CachiBot"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-cachi-600 hover:text-cachi-500 dark:text-cachi-400 dark:hover:text-cachi-300"
+            >
+              GitHub
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
         </div>
       </Section>
     </>
@@ -629,31 +682,6 @@ function DataSettings() {
             <Trash2 className="h-4 w-4" />
             Delete Everything
           </button>
-        </div>
-      </Section>
-
-      <Section icon={Info} title="About">
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-zinc-500 dark:text-zinc-400">Version</span>
-            <span className="font-mono text-zinc-800 dark:text-zinc-200">0.1.0</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-zinc-500 dark:text-zinc-400">Build</span>
-            <span className="font-mono text-zinc-800 dark:text-zinc-200">dev</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-zinc-500 dark:text-zinc-400">Documentation</span>
-            <a
-              href="https://github.com/jhd3197/CachiBot"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 text-cachi-600 hover:text-cachi-500 dark:text-cachi-400 dark:hover:text-cachi-300"
-            >
-              GitHub
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </div>
         </div>
       </Section>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ packages = ["src/cachibot"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "frontend/dist" = "cachibot/frontend_dist"
+"VERSION" = "cachibot/VERSION"
 
 [tool.ruff]
 target-version = "py310"

--- a/src/cachibot/__init__.py
+++ b/src/cachibot/__init__.py
@@ -5,7 +5,28 @@ A cross-platform AI agent with visual security.
 Powered by Prompture for structured LLM interaction.
 """
 
-__version__ = "0.2.0"
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+
+
+def _get_version() -> str:
+    """Get version from installed package metadata, VERSION file, or fallback."""
+    try:
+        return _pkg_version("cachibot")
+    except PackageNotFoundError:
+        pass
+    # Fallback: read VERSION file from repo root
+    from pathlib import Path
+
+    for candidate in [
+        Path(__file__).parent / "VERSION",  # bundled in package
+        Path(__file__).parent.parent.parent.parent / "VERSION",  # repo root (editable)
+    ]:
+        if candidate.exists():
+            return candidate.read_text().strip()
+    return "0.0.0-unknown"
+
+
+__version__ = _get_version()
 __author__ = "jhd3197"
 
 from cachibot.agent import CachibotAgent, Agent

--- a/src/cachibot/api/routes/health.py
+++ b/src/cachibot/api/routes/health.py
@@ -1,16 +1,33 @@
 """Health check endpoint."""
 
+import platform
+import sys
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from cachibot import __version__
+
 router = APIRouter()
+
+
+def _detect_build() -> str:
+    """Detect build type from version string."""
+    if ".dev" in __version__:
+        return "dev"
+    if __version__ == "0.0.0-unknown":
+        return "local"
+    return "release"
 
 
 class HealthResponse(BaseModel):
     """Health check response."""
 
     status: str = "ok"
-    version: str = "0.2.0"
+    version: str = __version__
+    build: str = _detect_build()
+    python: str = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    platform: str = platform.system().lower()
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/src/cachibot/api/server.py
+++ b/src/cachibot/api/server.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from cachibot import __version__
 from cachibot.api.routes import (
     auth,
     bots,
@@ -88,7 +89,7 @@ def create_app(
     app = FastAPI(
         title="Cachibot API",
         description="AI Agent API with WebSocket streaming",
-        version="0.2.0",
+        version=__version__,
         lifespan=lifespan,
     )
 
@@ -152,7 +153,7 @@ def create_app(
             """Root endpoint with API info."""
             return {
                 "name": "Cachibot API",
-                "version": "0.2.0",
+                "version": __version__,
                 "docs": "/docs",
                 "health": "/api/health",
             }


### PR DESCRIPTION
Write VERSION from CI and bundle it in the wheel, make package read version at runtime, and surface richer health metadata in the API and UI.

- CI: write the computed version to a VERSION file in dev and publish workflows.
- Packaging: include VERSION in wheel via pyproject.hatch config.
- Runtime: __init__ now resolves version from package metadata or a VERSION file (fallback) instead of a hardcoded string.
- API: /health response now returns version, build (dev/local/release), python and platform; server metadata uses __version__.
- Frontend: typed health client, fetch health on settings view and display About info (version, build, python, platform).
- Docs: README updated for installation, CLI usage, and default server URL/ports.

This enables reliable runtime version detection (including editable installs) and exposes build/runtime info for diagnostics in the UI.