### PR TITLE
Add provider management (API keys/endpoints)

### DIFF
--- a/frontend/src/api/providers.ts
+++ b/frontend/src/api/providers.ts
@@ -1,0 +1,74 @@
+/**
+ * Providers API client
+ */
+
+import { useAuthStore } from '../stores/auth'
+import { tryRefreshToken } from './auth'
+
+const API_BASE = '/api'
+
+export interface Provider {
+  name: string
+  env_key: string
+  type: 'api_key' | 'endpoint'
+  configured: boolean
+  masked_value: string
+  default: string
+}
+
+function getAuthHeader(): Record<string, string> {
+  const { accessToken } = useAuthStore.getState()
+  if (accessToken) {
+    return { Authorization: `Bearer ${accessToken}` }
+  }
+  return {}
+}
+
+async function request<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  retry = true
+): Promise<T> {
+  const url = `${API_BASE}${endpoint}`
+
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+      ...options.headers,
+    },
+    ...options,
+  })
+
+  if (response.status === 401 && retry) {
+    const newToken = await tryRefreshToken()
+    if (newToken) {
+      return request<T>(endpoint, options, false)
+    }
+  }
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.detail || `Request failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+export async function getProviders(): Promise<Provider[]> {
+  const data = await request<{ providers: Provider[] }>('/providers')
+  return data.providers
+}
+
+export async function updateProvider(name: string, value: string): Promise<void> {
+  await request(`/providers/${name}`, {
+    method: 'PUT',
+    body: JSON.stringify({ value }),
+  })
+}
+
+export async function deleteProvider(name: string): Promise<void> {
+  await request(`/providers/${name}`, {
+    method: 'DELETE',
+  })
+}

--- a/frontend/src/stores/providers.ts
+++ b/frontend/src/stores/providers.ts
@@ -1,0 +1,63 @@
+import { create } from 'zustand'
+import {
+  getProviders,
+  updateProvider,
+  deleteProvider,
+  type Provider,
+} from '../api/providers'
+
+interface ProvidersState {
+  providers: Provider[]
+  loading: boolean
+  error: string | null
+
+  refresh: () => Promise<void>
+  update: (name: string, value: string) => Promise<void>
+  remove: (name: string) => Promise<void>
+}
+
+export const useProvidersStore = create<ProvidersState>((set) => ({
+  providers: [],
+  loading: false,
+  error: null,
+
+  refresh: async () => {
+    set({ loading: true, error: null })
+    try {
+      const providers = await getProviders()
+      set({ providers, loading: false })
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to load providers',
+        loading: false,
+      })
+    }
+  },
+
+  update: async (name: string, value: string) => {
+    try {
+      await updateProvider(name, value)
+      // Refresh to get updated masked values
+      const providers = await getProviders()
+      set({ providers })
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to update provider',
+      })
+      throw err
+    }
+  },
+
+  remove: async (name: string) => {
+    try {
+      await deleteProvider(name)
+      const providers = await getProviders()
+      set({ providers })
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to remove provider',
+      })
+      throw err
+    }
+  },
+}))

--- a/src/cachibot/api/routes/__init__.py
+++ b/src/cachibot/api/routes/__init__.py
@@ -1,5 +1,5 @@
 """API route modules."""
 
-from cachibot.api.routes import auth, chat, config, creation, health, models, work
+from cachibot.api.routes import auth, chat, config, creation, health, models, providers, work
 
-__all__ = ["auth", "chat", "config", "creation", "health", "models", "work"]
+__all__ = ["auth", "chat", "config", "creation", "health", "models", "providers", "work"]

--- a/src/cachibot/api/routes/providers.py
+++ b/src/cachibot/api/routes/providers.py
@@ -1,0 +1,175 @@
+"""Provider API key management endpoints."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from cachibot.api.auth import get_current_user
+from cachibot.models.auth import User
+
+logger = logging.getLogger("cachibot.api.providers")
+router = APIRouter()
+
+PROVIDERS = {
+    "openai": {"env_key": "OPENAI_API_KEY", "type": "api_key"},
+    "claude": {"env_key": "CLAUDE_API_KEY", "type": "api_key"},
+    "google": {"env_key": "GOOGLE_API_KEY", "type": "api_key"},
+    "groq": {"env_key": "GROQ_API_KEY", "type": "api_key"},
+    "grok": {"env_key": "GROK_API_KEY", "type": "api_key"},
+    "openrouter": {"env_key": "OPENROUTER_API_KEY", "type": "api_key"},
+    "moonshot": {"env_key": "MOONSHOT_API_KEY", "type": "api_key"},
+    "zai": {"env_key": "ZHIPU_API_KEY", "type": "api_key"},
+    "modelscope": {"env_key": "MODELSCOPE_API_KEY", "type": "api_key"},
+    "azure": {
+        "env_key": "AZURE_API_KEY",
+        "type": "api_key",
+        "extra_keys": ["AZURE_API_ENDPOINT", "AZURE_DEPLOYMENT_ID"],
+    },
+    "ollama": {
+        "env_key": "OLLAMA_ENDPOINT",
+        "type": "endpoint",
+        "default": "http://localhost:11434/api/generate",
+    },
+    "lmstudio": {
+        "env_key": "LMSTUDIO_ENDPOINT",
+        "type": "endpoint",
+        "default": "http://127.0.0.1:1234/v1/chat/completions",
+    },
+    "local_http": {
+        "env_key": "LOCAL_HTTP_ENDPOINT",
+        "type": "endpoint",
+        "default": "http://localhost:8000/generate",
+    },
+}
+
+ENV_PATH = Path.cwd() / ".env"
+
+
+def _mask_value(value: str, provider_type: str) -> str:
+    """Mask API keys (show last 4 chars), show full URL for endpoints."""
+    if provider_type == "endpoint":
+        return value
+    if len(value) <= 4:
+        return "****"
+    return "*" * (len(value) - 4) + value[-4:]
+
+
+def _read_env_file() -> str:
+    """Read the .env file contents, return empty string if missing."""
+    if ENV_PATH.exists():
+        return ENV_PATH.read_text(encoding="utf-8")
+    return ""
+
+
+def _write_env_file(content: str) -> None:
+    """Write content to the .env file."""
+    ENV_PATH.write_text(content, encoding="utf-8")
+
+
+def _set_env_value(key: str, value: str) -> None:
+    """Set a key=value in the .env file, preserving comments and formatting."""
+    content = _read_env_file()
+    pattern = re.compile(rf"^#?\s*{re.escape(key)}\s*=.*$", re.MULTILINE)
+    replacement = f"{key}={value}"
+
+    if pattern.search(content):
+        content = pattern.sub(replacement, content, count=1)
+    else:
+        if content and not content.endswith("\n"):
+            content += "\n"
+        content += f"{replacement}\n"
+
+    _write_env_file(content)
+    os.environ[key] = value
+
+
+def _remove_env_value(key: str) -> None:
+    """Comment out a key in the .env file and remove from os.environ."""
+    content = _read_env_file()
+    pattern = re.compile(rf"^{re.escape(key)}\s*=.*$", re.MULTILINE)
+    content = pattern.sub(f"# {key}=", content)
+    _write_env_file(content)
+    os.environ.pop(key, None)
+
+
+class ProviderUpdate(BaseModel):
+    value: str
+
+
+@router.get("/providers")
+async def list_providers(user: User = Depends(get_current_user)):
+    """Return all known providers with configuration status."""
+    env_file_values: dict[str, str] = {}
+    content = _read_env_file()
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            env_file_values[k.strip()] = v.strip()
+
+    result = []
+    for name, info in PROVIDERS.items():
+        env_key = info["env_key"]
+        value = os.environ.get(env_key, "") or env_file_values.get(env_key, "")
+        if value and not os.environ.get(env_key):
+            os.environ[env_key] = value
+        configured = bool(value)
+        masked = _mask_value(value, info["type"]) if configured else ""
+        result.append(
+            {
+                "name": name,
+                "env_key": env_key,
+                "type": info["type"],
+                "configured": configured,
+                "masked_value": masked,
+                "default": info.get("default", ""),
+            }
+        )
+    return {"providers": result}
+
+
+@router.put("/providers/{name}")
+async def update_provider(
+    name: str,
+    body: ProviderUpdate,
+    user: User = Depends(get_current_user),
+):
+    """Set a provider's API key or endpoint."""
+    if name not in PROVIDERS:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {name}")
+
+    info = PROVIDERS[name]
+    _set_env_value(info["env_key"], body.value)
+
+    # Trigger model re-discovery so new models appear immediately
+    models = []
+    try:
+        from prompture import get_available_models
+
+        models = get_available_models()
+    except Exception as exc:
+        logger.warning("Model re-discovery after provider update failed: %s", exc)
+
+    return {"ok": True, "models": models}
+
+
+@router.delete("/providers/{name}")
+async def delete_provider(
+    name: str,
+    user: User = Depends(get_current_user),
+):
+    """Remove a provider's API key or endpoint."""
+    if name not in PROVIDERS:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {name}")
+
+    info = PROVIDERS[name]
+    _remove_env_value(info["env_key"])
+    return {"ok": True}

--- a/src/cachibot/api/server.py
+++ b/src/cachibot/api/server.py
@@ -28,6 +28,7 @@ from cachibot.api.routes import (
     instructions,
     marketplace,
     models,
+    providers,
     skills,
     work,
 )
@@ -116,6 +117,7 @@ def create_app(
     app.include_router(auth.router, prefix="/api", tags=["auth"])
     app.include_router(health.router, prefix="/api", tags=["health"])
     app.include_router(models.router, prefix="/api", tags=["models"])
+    app.include_router(providers.router, prefix="/api", tags=["providers"])
     app.include_router(config.router, prefix="/api", tags=["config"])
     app.include_router(chat.router, prefix="/api", tags=["chat"])
     app.include_router(creation.router, prefix="/api", tags=["creation"])


### PR DESCRIPTION
Add backend and frontend support for managing AI provider API keys and endpoints. Backend: introduce providers API (GET /providers, PUT /providers/{name}, DELETE /providers/{name}) that reads/writes .env and os.environ, masks values for display, and triggers model re-discovery after updates; register the providers router in the server and routes package. Frontend: add providers API client (frontend/src/api/providers.ts), a zustand providers store (frontend/src/stores/providers.ts), and an API Keys settings UI in AppSettingsView (new 'keys' tab) to save, remove, and toggle visibility of provider keys for cloud and local providers. Also update imports/icons and wire model refresh after changes.