### PR TITLE
Add max_tokens config and pass to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ nul
 error.log
 website/*
 settings.local.json
+.marketing/

--- a/cachibot.example.toml
+++ b/cachibot.example.toml
@@ -16,6 +16,10 @@ approve_actions = false
 # Moonshot recommends 0.6 for instant mode, 1.0 for thinking mode
 temperature = 0.6
 
+# Maximum output tokens per LLM call
+# Higher values allow the agent to write longer files and tool outputs
+max_tokens = 4096
+
 [sandbox]
 # Allowed Python imports (safe modules only)
 # Add more as needed, but be careful with security implications

--- a/src/cachibot/agent.py
+++ b/src/cachibot/agent.py
@@ -699,7 +699,6 @@ class CachibotAgent:
         )
 
         # Create agent
-        # Note: temperature is configured at the model/provider level, not Agent level
         self._agent = PromptureAgent(
             model=self.config.agent.model,
             tools=self.registry,
@@ -707,6 +706,10 @@ class CachibotAgent:
             agent_callbacks=callbacks,
             max_iterations=self.config.agent.max_iterations,
             persistent_conversation=True,
+            options={
+                "temperature": self.config.agent.temperature,
+                "max_tokens": self.config.agent.max_tokens,
+            },
         )
 
     def _get_system_prompt(self) -> str:

--- a/src/cachibot/config.py
+++ b/src/cachibot/config.py
@@ -73,6 +73,7 @@ class AgentConfig:
     max_iterations: int = 20
     approve_actions: bool = False
     temperature: float = 0.6  # Moonshot recommends 0.6 for instant mode
+    max_tokens: int = 4096  # Max output tokens per LLM call
 
 
 @dataclass
@@ -207,6 +208,13 @@ class Config:
             except ValueError:
                 pass
 
+        # Max tokens
+        if max_tok := os.getenv("CACHIBOT_MAX_TOKENS"):
+            try:
+                self.agent.max_tokens = int(max_tok)
+            except ValueError:
+                pass
+
         # Sandbox timeout
         if timeout := os.getenv("CACHIBOT_SANDBOX_TIMEOUT"):
             try:
@@ -257,6 +265,8 @@ class Config:
                 self.agent.approve_actions = agent_data["approve_actions"]
             if "temperature" in agent_data:
                 self.agent.temperature = agent_data["temperature"]
+            if "max_tokens" in agent_data:
+                self.agent.max_tokens = agent_data["max_tokens"]
 
         if sandbox_data := data.get("sandbox"):
             if "allowed_imports" in sandbox_data:


### PR DESCRIPTION
Introduce a max_tokens setting (default 4096) to control maximum LLM output length: added to AgentConfig, documented in cachibot.example.toml, and parsed from CACHIBOT_MAX_TOKENS env or config file. Propagate the value into PromptureAgent via options (alongside temperature). Also minor .gitignore cleanup (fix newline for settings.local.json and add .marketing/).