### PR TITLE
Add architecture docs; support rich config types

### DIFF
--- a/_test_async_extract.py
+++ b/_test_async_extract.py
@@ -1,0 +1,22 @@
+"""Test the new name generator."""
+import asyncio
+import logging
+from cachibot.services.name_generator import generate_bot_names_with_meanings
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def main():
+    try:
+        names = await generate_bot_names_with_meanings(
+            count=4,
+            purpose="Cooking & Recipes: Help me cook healthy meals",
+        )
+        print("SUCCESS! Names:")
+        for n in names:
+            print(f"  {n.name}: {n.meaning}")
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+
+
+asyncio.run(main())

--- a/cachibot.example.toml
+++ b/cachibot.example.toml
@@ -6,6 +6,10 @@
 # Options: moonshot/kimi-k2.5, claude/claude-sonnet-4-20250514, openai/gpt-4o, ollama/llama3.1:8b
 model = "moonshot/kimi-k2.5"
 
+# Cheap/fast model for utility tasks (name generation, follow-up questions)
+# Falls back to the main model if empty
+# utility_model = "anthropic/claude-3-5-haiku-20241022"
+
 # Maximum agent iterations per request
 max_iterations = 20
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,686 @@
+# CachiBot + Prompture + Tukuy — Architecture Guide
+
+How the three libraries work together to deliver a security-focused, plugin-driven AI agent with a fully dynamic frontend.
+
+---
+
+## Stack at a Glance
+
+| Layer | Library | Role |
+|-------|---------|------|
+| **LLM orchestration** | [Prompture](https://pypi.org/project/prompture/) `>=1.0.15` | `AsyncAgent`, `ToolRegistry`, `PythonSandbox`, `AgentCallbacks`, risk analysis |
+| **Plugin framework** | [Tukuy](https://pypi.org/project/tukuy/) `>=0.1.0` | `TransformerPlugin`, `@skill` decorator, `PluginManifest`, `RiskLevel`, `ConfigParam` |
+| **Application** | CachiBot | Agent dataclass, capability gating, API server, React frontend |
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        React Frontend                            │
+│  ToolsView ─ ToolConfigDialog ─ ToolIconRenderer ─ ChatView     │
+│        ▲             ▲                                           │
+│        │  REST       │  WebSocket                                │
+├────────┼─────────────┼───────────────────────────────────────────┤
+│        │  FastAPI     │                                           │
+│  /api/plugins    /ws ──► CachibotAgent                           │
+│                          │                                       │
+│                   ┌──────┴──────┐                                │
+│              Prompture      Plugin Manager                       │
+│           AsyncAgent        (capability gate)                    │
+│           ToolRegistry           │                               │
+│           PythonSandbox    ┌─────┴──────────┐                    │
+│           SecurityContext  │  Tukuy Plugins  │                   │
+│                            │  @skill()       │                   │
+│                            │  PluginManifest │                   │
+│                            │  ConfigParam    │                   │
+│                            └────────────────┘                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. Tukuy — The Plugin Framework
+
+Tukuy provides the plugin model. Every tool CachiBot exposes — whether custom or built-in — is a Tukuy plugin containing one or more **skills**.
+
+### 1.1 PluginManifest
+
+Each plugin declares identity and requirements via `PluginManifest`:
+
+```python
+from tukuy.manifest import PluginManifest
+
+@property
+def manifest(self) -> PluginManifest:
+    return PluginManifest(
+        name="file_ops",
+        display_name="File Operations",
+        icon="folder",              # Lucide icon name
+        group="Core",
+        requires_filesystem=True,
+    )
+```
+
+The manifest is serialized by the `/api/plugins` endpoint and consumed by the frontend to render plugin headers, icons, and groupings — **no hardcoded UI metadata needed**.
+
+### 1.2 @skill Decorator
+
+Individual tools are defined with `@skill()`, which attaches a `SkillDescriptor` to the function:
+
+```python
+from tukuy.skill import skill, RiskLevel, ConfigParam
+
+@skill(
+    name="python_execute",
+    description="Execute Python code in a sandboxed environment",
+    category="code",
+    tags=["python", "sandbox", "execution"],
+    display_name="Execute Python",
+    icon="code",
+    risk_level=RiskLevel.DANGEROUS,
+    side_effects=True,
+    requires_filesystem=True,
+    config_params=[
+        ConfigParam(
+            name="timeoutSeconds",
+            display_name="Timeout",
+            type="number",
+            default=30,
+            min=5,
+            max=120,
+            step=5,
+            unit="seconds",
+            description="Maximum execution time",
+        ),
+        ConfigParam(
+            name="maxOutputLength",
+            display_name="Max Output",
+            type="number",
+            default=10000,
+            min=1000,
+            max=50000,
+            step=1000,
+            unit="chars",
+        ),
+    ],
+)
+def python_execute(code: str) -> str:
+    ...
+```
+
+**Key metadata fields:**
+
+| Field | Purpose | Frontend use |
+|-------|---------|--------------|
+| `display_name` | Human-readable label | Tool card title |
+| `icon` | Lucide icon name | `ToolIconRenderer` |
+| `risk_level` | `SAFE` / `MODERATE` / `DANGEROUS` / `CRITICAL` | Risk badge color |
+| `config_params` | Configurable parameters with validation | `ToolConfigDialog` generic form |
+| `category` | Functional grouping | Filter chips |
+| `tags` | Searchable keywords | Search |
+| `hidden` | Exclude from UI | Filtered out |
+| `deprecated` | Deprecation notice | Strike-through + notice |
+
+### 1.3 RiskLevel Enum
+
+```python
+class RiskLevel(Enum):
+    SAFE      = "safe"       # Read-only, no side effects
+    MODERATE  = "moderate"   # Limited side effects
+    DANGEROUS = "dangerous"  # Can modify files, execute code
+    CRITICAL  = "critical"   # Network access, credentials, system changes
+```
+
+Risk levels drive both the UI badge styling and the approval flow — `DANGEROUS` and `CRITICAL` operations can trigger an approval callback before execution.
+
+### 1.4 ConfigParam
+
+`ConfigParam` defines a configurable parameter that the frontend renders dynamically:
+
+```python
+ConfigParam(
+    name="timeoutSeconds",       # Key in tool_configs dict
+    display_name="Timeout",      # Label in UI
+    description="Max execution time",
+    type="number",               # number | string | boolean | select
+    default=30,
+    min=5,                       # For number type
+    max=120,
+    step=5,
+    unit="seconds",              # Shown next to value
+    options=None,                # For select type
+    scope="per_bot",             # global | per_bot | per_call
+)
+```
+
+The frontend `ToolConfigDialog` renders each param type as:
+- **`number`** → Range slider with min/max/step and unit label
+- **`boolean`** → Toggle switch
+- **`select`** → Dropdown from `options[]`
+- **`string`** → Text input
+
+### 1.5 Built-in Tukuy Plugins
+
+Tukuy ships with plugins that CachiBot enables based on capabilities:
+
+| Plugin | Skills | Capability |
+|--------|--------|------------|
+| `GitPlugin` | git_status, git_diff, git_commit, ... | `gitOperations` |
+| `ShellPlugin` | shell_run | `shellAccess` |
+| `WebPlugin` | web_search, web_fetch | `webAccess` |
+| `HttpPlugin` | http_request | `webAccess` |
+| `SqlPlugin` | sqlite_query, sqlite_execute | `dataOperations` |
+| `CompressionPlugin` | zip_create, tar_extract, ... | `dataOperations` |
+
+These plugins are scoped to the workspace via Prompture's `SecurityContext` (see section 2.3).
+
+---
+
+## 2. Prompture — LLM Orchestration
+
+Prompture handles the agent loop: model calls, tool dispatch, conversation management, and security enforcement.
+
+### 2.1 ToolRegistry
+
+The central registry that maps tool names to callable functions. The plugin manager bridges Tukuy skills into Prompture:
+
+```python
+# plugin_manager.py
+def plugins_to_registry(plugins: list[TransformerPlugin]) -> ToolRegistry:
+    registry = ToolRegistry()
+    for plugin in plugins:
+        for skill_obj in plugin.skills.values():
+            registry.add_tukuy_skill(skill_obj)  # Preserves Tukuy metadata
+    return registry
+```
+
+`add_tukuy_skill()` (Prompture 1.0.15+) accepts a Tukuy `Skill` object directly instead of a plain function, preserving all `SkillDescriptor` metadata through the bridge. This is what allows the `/api/plugins` endpoint to introspect skill metadata even though the agent uses Prompture's registry at runtime.
+
+### 2.2 AsyncAgent
+
+Prompture's `AsyncAgent` is the runtime engine:
+
+```python
+agent = PromptureAgent(
+    model="openai/gpt-4o",           # Provider/model string
+    tools=registry,                    # ToolRegistry with all skills
+    system_prompt=system_prompt,
+    agent_callbacks=callbacks,         # Streaming events
+    max_iterations=25,
+    persistent_conversation=True,
+    security_context=security_ctx,     # Sandbox-derived security
+    options={"max_tokens": 8192},
+)
+```
+
+The agent loop:
+1. Sends user message + conversation history to the LLM
+2. LLM decides to call a tool or respond
+3. If tool call → dispatch through `ToolRegistry` → return result to LLM
+4. Repeat until the LLM produces a final text response or hits `max_iterations`
+
+### 2.3 PythonSandbox & SecurityContext
+
+`PythonSandbox` restricts code execution:
+
+```python
+sandbox = PythonSandbox(
+    allowed_imports=["math", "json", "re", "datetime", ...],
+    timeout_seconds=60,
+    allowed_read_paths=[workspace_path],
+    allowed_write_paths=[workspace_path],
+)
+```
+
+The sandbox converts to a `SecurityContext` that also scopes Tukuy's built-in plugins:
+
+```python
+security_ctx = sandbox.to_security_context()
+# Now GitPlugin can only operate within workspace_path
+# ShellPlugin commands are restricted to workspace_path
+```
+
+### 2.4 AgentCallbacks
+
+Prompture streams events through callbacks that CachiBot forwards over WebSocket:
+
+```python
+callbacks = AgentCallbacks(
+    on_thinking=lambda text: send_ws("thinking", text),
+    on_tool_start=lambda name, args: send_ws("tool_start", {name, args}),
+    on_tool_end=lambda name, result: send_ws("tool_end", {name, result}),
+    on_message=lambda text: send_ws("message", text),
+    on_approval_needed=lambda tool, action, details: prompt_user(tool),
+)
+```
+
+### 2.5 Risk Analysis (python_execute)
+
+For code execution, Prompture provides AST-based risk analysis:
+
+```python
+from prompture import analyze_python
+
+risk = analyze_python(code)
+# risk.level: LOW | MODERATE | HIGH | CRITICAL
+# risk.reasons: ["Uses subprocess", "Writes to /etc/..."]
+
+if risk.level in (RiskLevel.HIGH, RiskLevel.CRITICAL):
+    raise ApprovalRequired(tool="python_execute", details=risk.reasons)
+```
+
+This integrates with the `on_approval_needed` callback — the frontend shows a confirmation dialog before the agent proceeds.
+
+---
+
+## 3. CachiBot — The Application Layer
+
+CachiBot ties Prompture and Tukuy together with capability gating, bot-scoped configuration, and a full React UI.
+
+### 3.1 Plugin Context
+
+Every CachiBot plugin receives a `PluginContext` with runtime dependencies:
+
+```python
+@dataclass
+class PluginContext:
+    config: Config                # App configuration
+    sandbox: PythonSandbox       # Prompture sandbox instance
+    bot_id: str | None           # Active bot identity
+    tool_configs: dict           # Per-tool settings from bot config
+```
+
+Custom plugins extend `CachibotPlugin(TransformerPlugin)` and receive the context:
+
+```python
+class FileOpsPlugin(CachibotPlugin):
+    def __init__(self, ctx: PluginContext) -> None:
+        super().__init__("file_ops", ctx)
+        self._skills_map = self._build_skills()
+```
+
+Tukuy built-in plugins (Git, Shell, Web, etc.) don't need the context — they're scoped through Prompture's `SecurityContext`.
+
+### 3.2 Plugin Manager & Capability Gating
+
+The plugin manager maps bot capabilities to plugin classes:
+
+```python
+CAPABILITY_PLUGINS = {
+    "fileOperations":  [FileOpsPlugin],
+    "codeExecution":   [PythonSandboxPlugin],
+    "gitOperations":   [GitPlugin],
+    "shellAccess":     [ShellPlugin],
+    "webAccess":       [WebPlugin, HttpPlugin],
+    "dataOperations":  [SqlPlugin, CompressionPlugin],
+    "connections":     [PlatformPlugin],
+    "workManagement":  [WorkManagementPlugin],
+}
+
+ALWAYS_ENABLED = [TaskPlugin]  # Always available
+```
+
+When a bot is created or updated, only plugins whose capabilities are enabled get instantiated and registered:
+
+```python
+def build_registry(ctx: PluginContext, capabilities: dict | None) -> ToolRegistry:
+    plugins = _instantiate_plugins(ctx, capabilities)
+    return plugins_to_registry(plugins)
+```
+
+### 3.3 CachibotAgent
+
+The agent dataclass orchestrates everything:
+
+```python
+@dataclass
+class CachibotAgent:
+    config: Config
+    registry: ToolRegistry
+    sandbox: PythonSandbox | None
+    capabilities: dict | None
+    tool_configs: dict | None
+    bot_id: str | None
+
+    # Callbacks for UI streaming
+    on_thinking: Callable | None
+    on_tool_start: Callable | None
+    on_tool_end: Callable | None
+    on_message: Callable | None
+    on_approval_needed: Callable | None
+```
+
+**Initialization sequence:**
+
+```
+CachibotAgent.__post_init__()
+  ├─ _setup_sandbox()
+  │    └─ PythonSandbox(allowed_imports, timeout, paths)
+  ├─ _build_registry_from_plugins()
+  │    ├─ PluginContext(config, sandbox, bot_id, tool_configs)
+  │    └─ build_registry(ctx, capabilities)
+  │         ├─ Instantiate enabled plugins
+  │         └─ registry.add_tukuy_skill() for each skill
+  └─ _create_agent()
+       ├─ AgentCallbacks from instance callbacks
+       ├─ SecurityContext from sandbox
+       └─ PromptureAgent(model, tools, callbacks, security_context)
+```
+
+### 3.4 Per-Bot Configuration
+
+Each bot carries its own capabilities and tool configurations:
+
+```typescript
+{
+  id: "bot-abc",
+  name: "Security Analyst",
+  capabilities: {
+    codeExecution: true,
+    fileOperations: true,
+    gitOperations: false,
+    shellAccess: false,
+    webAccess: true,
+    dataOperations: false,
+    connections: true,
+    workManagement: true
+  },
+  toolConfigs: {
+    "python_execute": {
+      "timeoutSeconds": 60,
+      "maxOutputLength": 20000
+    }
+  },
+  tools: ["task_complete", "file_read", "file_write", "python_execute", ...]
+}
+```
+
+**Resolution order:**
+1. **Capabilities** → enable/disable entire plugin groups
+2. **Tool Configs** → configure individual tool parameters (fed into `PluginContext`)
+3. **Allowed Tools** → fine-grained whitelist on the registry
+
+---
+
+## 4. Frontend — API-Driven UI
+
+The frontend has **zero hardcoded tool metadata**. Everything is driven by the `/api/plugins` endpoint.
+
+### 4.1 Plugin API Response
+
+```
+GET /api/plugins
+```
+
+```json
+{
+  "plugins": [
+    {
+      "name": "file_ops",
+      "class": "FileOpsPlugin",
+      "capability": "fileOperations",
+      "alwaysEnabled": false,
+      "displayName": "File Operations",
+      "icon": "folder",
+      "color": null,
+      "group": "Core",
+      "skills": [
+        {
+          "name": "file_read",
+          "description": "Read contents of a file",
+          "category": "file",
+          "tags": ["file", "read", "workspace"],
+          "displayName": "Read File",
+          "icon": "file-text",
+          "riskLevel": "safe",
+          "configParams": [],
+          "hidden": false,
+          "deprecated": null
+        },
+        {
+          "name": "file_write",
+          "description": "Write content to a file",
+          "displayName": "Write File",
+          "icon": "file-plus",
+          "riskLevel": "moderate",
+          "configParams": [],
+          ...
+        }
+      ]
+    },
+    {
+      "name": "python_sandbox",
+      "displayName": "Code Execution",
+      "icon": "code",
+      "group": "Core",
+      "skills": [
+        {
+          "name": "python_execute",
+          "displayName": "Execute Python",
+          "icon": "code",
+          "riskLevel": "dangerous",
+          "configParams": [
+            {
+              "name": "timeoutSeconds",
+              "displayName": "Timeout",
+              "type": "number",
+              "default": 30,
+              "min": 5,
+              "max": 120,
+              "step": 5,
+              "unit": "seconds"
+            },
+            {
+              "name": "maxOutputLength",
+              "displayName": "Max Output",
+              "type": "number",
+              "default": 10000,
+              "min": 1000,
+              "max": 50000,
+              "step": 1000,
+              "unit": "chars"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 4.2 ToolIconRenderer
+
+Two-tier icon resolution:
+
+1. **API-driven** — `icon` from `SkillDescriptor` → looked up in `lucideIconMap`
+2. **Legacy fallback** — `toolId` → looked up in `toolIconMap`
+
+```tsx
+<ToolIconRenderer toolId="python_execute" icon="code" size={20} />
+```
+
+The `resolveIconName()` export handles plugin header icons from `PluginManifest.icon`.
+
+### 4.3 ToolsView
+
+Fetches plugins → transforms skills to `Tool[]` → groups by plugin → renders:
+
+- Plugin headers with manifest icon and display name
+- Tool cards with skill icon, display name, risk badge, toggle
+- Category filter chips derived from skill categories
+- Search across skill names, descriptions, and tags
+- Configure button only appears for tools with `configParams.length > 0`
+
+### 4.4 ToolConfigDialog
+
+Generic configuration form driven entirely by `ConfigParam[]`:
+
+```tsx
+// For each param in tool.configParams:
+switch (param.type) {
+  case 'number':  // Range slider with min/max/step + unit label
+  case 'boolean': // Toggle switch
+  case 'select':  // Dropdown from param.options[]
+  case 'string':  // Text input
+}
+```
+
+Values are stored per-bot in `bot.toolConfigs[toolId]` and passed through `PluginContext.tool_configs` on the next agent run.
+
+---
+
+## 5. Security Model
+
+Seven layers from UI to execution:
+
+| # | Layer | Where | What it does |
+|---|-------|-------|--------------|
+| 1 | **Capability gate** | Plugin Manager | Enable/disable plugin categories per bot |
+| 2 | **Tool whitelist** | CachibotAgent | `allowed_tools` set filters the registry |
+| 3 | **Sandbox** | Prompture | Restrict imports, paths, and timeout for `python_execute` |
+| 4 | **SecurityContext** | Prompture → Tukuy | Scope Git/Shell/Web plugins to workspace directory |
+| 5 | **Risk analysis** | Prompture | AST analysis flags dangerous code patterns |
+| 6 | **Approval flow** | Agent → WebSocket → UI | User confirms high-risk operations before execution |
+| 7 | **Config limits** | PluginContext | Enforce timeouts, output length, and other bounds |
+
+---
+
+## 6. Data Flow — End to End
+
+### Tool Execution
+
+```
+User types message
+  │
+  ▼
+Frontend sends over WebSocket (/ws)
+  │
+  ▼
+CachibotAgent.run_stream(message)
+  │
+  ├─► Prompture AsyncAgent calls LLM
+  │     LLM returns tool_call: { name: "python_execute", args: { code: "..." } }
+  │
+  ├─► ToolRegistry dispatches to skill function
+  │     ├─ analyze_python(code) → risk assessment
+  │     ├─ If HIGH/CRITICAL → ApprovalRequired → on_approval_needed callback
+  │     │   └─ Frontend shows confirmation dialog
+  │     ├─ PythonSandbox.execute(code, timeout=tool_configs["timeoutSeconds"])
+  │     └─ Returns result string
+  │
+  ├─► Callbacks fire:
+  │     on_tool_start("python_execute", {code: "..."}) → WS "tool_start"
+  │     on_tool_end("python_execute", result)           → WS "tool_end"
+  │
+  ├─► LLM receives result, decides next action or final response
+  │
+  └─► on_message(response) → WS "message"
+        Frontend appends to chat history
+```
+
+### Plugin Discovery
+
+```
+Frontend mounts ToolsView
+  │
+  ├─► GET /api/plugins
+  │     Backend introspects all plugin classes
+  │     Extracts PluginManifest + SkillDescriptor metadata
+  │     Returns PluginInfo[] with full metadata
+  │
+  ├─► Frontend maps skills → Tool[] with icons, risk levels, config params
+  │
+  └─► Renders:
+        Plugin groups with manifest headers
+        Tool cards with skill metadata
+        Config buttons for tools with ConfigParam[]
+        Risk badges from RiskLevel
+```
+
+---
+
+## 7. Adding a New Plugin
+
+```python
+# src/cachibot/plugins/my_plugin.py
+from tukuy.manifest import PluginManifest
+from tukuy.skill import skill, RiskLevel, ConfigParam, Skill
+from cachibot.plugins.base import CachibotPlugin, PluginContext
+
+
+class MyPlugin(CachibotPlugin):
+    def __init__(self, ctx: PluginContext) -> None:
+        super().__init__("my_plugin", ctx)
+        self._skills_map = self._build_skills()
+
+    @property
+    def manifest(self) -> PluginManifest:
+        return PluginManifest(
+            name="my_plugin",
+            display_name="My Plugin",
+            icon="puzzle",
+            group="Custom",
+        )
+
+    def _build_skills(self) -> dict[str, Skill]:
+        ctx = self.ctx
+
+        @skill(
+            name="my_tool",
+            description="Does something useful",
+            category="custom",
+            display_name="My Tool",
+            icon="zap",
+            risk_level=RiskLevel.SAFE,
+            config_params=[
+                ConfigParam(
+                    name="limit",
+                    display_name="Result Limit",
+                    type="number",
+                    default=10,
+                    min=1,
+                    max=100,
+                ),
+            ],
+        )
+        def my_tool(query: str) -> str:
+            limit = ctx.tool_configs.get("my_tool", {}).get("limit", 10)
+            return f"Results for '{query}' (limit={limit})"
+
+        return {"my_tool": my_tool.__skill__}
+
+    @property
+    def skills(self) -> dict[str, Skill]:
+        return self._skills_map
+```
+
+Register in the plugin manager:
+
+```python
+# plugin_manager.py
+CAPABILITY_PLUGINS["customFeature"] = [MyPlugin]
+```
+
+That's it. The frontend automatically:
+- Shows "My Plugin" with a puzzle icon in the Tools view
+- Renders "My Tool" with a zap icon and a "safe" badge
+- Offers a "Configure" button with a "Result Limit" slider (1–100)
+- Saves config per bot and passes it through on the next agent run
+
+---
+
+## 8. Key Files Reference
+
+| File | What it does |
+|------|-------------|
+| `src/cachibot/plugins/base.py` | `PluginContext`, `CachibotPlugin` base class |
+| `src/cachibot/plugins/task.py` | `TaskPlugin` — always-on task completion skill |
+| `src/cachibot/plugins/file_ops.py` | `FileOpsPlugin` — file read/write/list/edit/info |
+| `src/cachibot/plugins/python_sandbox.py` | `PythonSandboxPlugin` — sandboxed code execution |
+| `src/cachibot/plugins/platform.py` | `PlatformPlugin` — Telegram & Discord integration |
+| `src/cachibot/plugins/work_management.py` | `WorkManagementPlugin` — work items & todos |
+| `src/cachibot/services/plugin_manager.py` | Capability mapping, instantiation, registry bridge |
+| `src/cachibot/agent.py` | `CachibotAgent` — orchestrates Prompture + plugins |
+| `src/cachibot/api/routes/plugins.py` | `/api/plugins` introspection endpoint |
+| `frontend/src/types/index.ts` | `PluginInfo`, `PluginSkillInfo`, `ConfigParam` types |
+| `frontend/src/components/views/ToolsView.tsx` | Tool discovery and management UI |
+| `frontend/src/components/dialogs/ToolConfigDialog.tsx` | Generic config form from ConfigParam[] |
+| `frontend/src/components/common/ToolIconRenderer.tsx` | API-driven icon resolution |

--- a/frontend/src/components/dialogs/CreateBotWizard/steps/NamePickerStep.tsx
+++ b/frontend/src/components/dialogs/CreateBotWizard/steps/NamePickerStep.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Loader2, RefreshCw, Sparkles, Check } from 'lucide-react'
 import { useCreationStore, PURPOSE_CATEGORIES } from '../../../../stores/creation'
-import { generateBotNamesWithMeanings } from '../../../../api/client'
+import { streamBotNamesWithMeanings } from '../../../../api/client'
 import { cn } from '../../../../lib/utils'
 
 export function NamePickerStep() {
@@ -11,39 +11,91 @@ export function NamePickerStep() {
     isGenerating,
     setGenerating,
     setGenerationError,
-    setNameSuggestions,
     selectName,
+    getExcludedNames,
   } = useCreationStore()
 
-  // Load name suggestions when entering step
+  // Guard against StrictMode double-fire
+  const loadInitiatedRef = useRef(false)
+  const abortRef = useRef<AbortController | null>(null)
+
   useEffect(() => {
-    if (form.nameSuggestions.length === 0 && !isGenerating) {
+    if (form.nameSuggestions.length === 0 && !isGenerating && !loadInitiatedRef.current) {
+      loadInitiatedRef.current = true
       loadNameSuggestions()
+    }
+    return () => {
+      abortRef.current?.abort()
     }
   }, [])
 
   const loadNameSuggestions = async () => {
+    // Abort any in-flight request
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     setGenerating(true)
     setGenerationError(null)
+
+    // Clear existing suggestions for a fresh batch
+    const store = useCreationStore.getState()
+    // Track names added during this batch for auto-select
+    const newNames: Array<{ name: string; meaning: string }> = []
+    let isFirstName = true
 
     try {
       const categoryLabel = PURPOSE_CATEGORIES.find(c => c.id === form.purposeCategory)?.label || form.purposeCategory
 
-      const names = await generateBotNamesWithMeanings({
-        count: 4,
-        purpose: `${categoryLabel}: ${form.purposeDescription}`,
-      })
-      setNameSuggestions(names)
+      await streamBotNamesWithMeanings(
+        {
+          count: 4,
+          exclude: getExcludedNames(),
+          purpose: `${categoryLabel}: ${form.purposeDescription}`,
+        },
+        {
+          onName: (nameData) => {
+            newNames.push(nameData)
+            // Append name incrementally to the store
+            useCreationStore.setState((state) => ({
+              form: {
+                ...state.form,
+                nameSuggestions: [...state.form.nameSuggestions, { name: nameData.name, meaning: nameData.meaning }],
+              },
+            }))
 
-      // Auto-select the first name if no name selected yet
-      if (!form.name && names.length > 0) {
-        selectName(names[0].name, names[0].meaning)
-      }
+            // Auto-select the first name if none selected
+            if (isFirstName && !store.form.name) {
+              selectName(nameData.name, nameData.meaning)
+              isFirstName = false
+            }
+          },
+          onDone: () => {
+            setGenerating(false)
+          },
+          onError: (error) => {
+            setGenerationError(error)
+            setGenerating(false)
+          },
+        },
+        controller.signal,
+      )
     } catch (error) {
-      setGenerationError(error instanceof Error ? error.message : 'Failed to generate names')
-    } finally {
-      setGenerating(false)
+      if ((error as Error).name !== 'AbortError') {
+        setGenerationError(error instanceof Error ? error.message : 'Failed to generate names')
+        setGenerating(false)
+      }
     }
+  }
+
+  const handleRefresh = () => {
+    // Move current names to excluded before loading new ones
+    const currentNames = useCreationStore.getState().form.nameSuggestions
+    useCreationStore.setState((state) => ({
+      excludedNames: [...new Set([...state.excludedNames, ...currentNames.map(s => s.name)])],
+      form: { ...state.form, nameSuggestions: [] },
+    }))
+    loadNameSuggestions()
   }
 
   const handleSelectName = (name: string, meaning: string) => {
@@ -77,7 +129,7 @@ export function NamePickerStep() {
           <span className="text-sm font-medium text-zinc-300">Pick a name that resonates with you</span>
         </div>
         <button
-          onClick={loadNameSuggestions}
+          onClick={handleRefresh}
           disabled={isGenerating}
           className="flex items-center gap-1.5 text-xs text-cachi-400 hover:text-cachi-300 disabled:opacity-50"
         >
@@ -88,17 +140,19 @@ export function NamePickerStep() {
 
       {/* Name cards */}
       <div className="grid grid-cols-2 gap-3">
-        {form.nameSuggestions.map((suggestion) => (
+        {form.nameSuggestions.map((suggestion, index) => (
           <button
             key={suggestion.name}
             onClick={() => handleSelectName(suggestion.name, suggestion.meaning)}
-            disabled={isGenerating}
+            disabled={isGenerating && form.nameSuggestions.length < 4}
             className={cn(
               'group relative rounded-xl border p-4 text-left transition-all',
+              'animate-in fade-in slide-in-from-bottom-2 duration-300',
               form.name === suggestion.name
                 ? 'border-cachi-500 bg-cachi-500/10 ring-1 ring-cachi-500/50'
                 : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600 hover:bg-zinc-800'
             )}
+            style={{ animationDelay: `${index * 100}ms`, animationFillMode: 'backwards' }}
           >
             {form.name === suggestion.name && (
               <div className="absolute right-3 top-3">
@@ -118,6 +172,19 @@ export function NamePickerStep() {
             </p>
           </button>
         ))}
+
+        {/* Placeholder cards while streaming */}
+        {isGenerating && form.nameSuggestions.length < 4 &&
+          Array.from({ length: 4 - form.nameSuggestions.length }).map((_, i) => (
+            <div
+              key={`placeholder-${i}`}
+              className="flex items-center justify-center rounded-xl border border-zinc-800 bg-zinc-800/30 p-4"
+              style={{ minHeight: '100px' }}
+            >
+              <Loader2 className="h-5 w-5 animate-spin text-zinc-600" />
+            </div>
+          ))
+        }
       </div>
 
       {/* Custom name input */}

--- a/frontend/src/components/dialogs/OnboardingWizard/index.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/index.tsx
@@ -1,0 +1,147 @@
+import { Rocket } from 'lucide-react'
+import { useOnboardingStore, ONBOARDING_STEPS } from '../../../stores/onboarding'
+import { useProvidersStore } from '../../../stores/providers'
+import { useModelsStore } from '../../../stores/models'
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogFooter,
+  DialogButton,
+  DialogStepper,
+  type Step,
+} from '../../common/Dialog'
+import { WelcomeStep } from './steps/WelcomeStep'
+import { ApiKeyStep } from './steps/ApiKeyStep'
+import { ModelStep } from './steps/ModelStep'
+import { PreferencesStep } from './steps/PreferencesStep'
+import { CompleteStep } from './steps/CompleteStep'
+
+const WIZARD_STEPS: Step[] = [
+  { id: 'welcome', label: 'Welcome' },
+  { id: 'api-key', label: 'API Key' },
+  { id: 'model', label: 'Model' },
+  { id: 'preferences', label: 'Style' },
+  { id: 'complete', label: 'Done' },
+]
+
+function getStepSubtitle(step: string): string {
+  const subtitles: Record<string, string> = {
+    welcome: 'Get started with CachiBot',
+    'api-key': 'Connect an AI provider',
+    model: 'Choose your default model',
+    preferences: 'Personalize your experience',
+    complete: 'Setup complete',
+  }
+  return subtitles[step] || ''
+}
+
+export function OnboardingWizard() {
+  const {
+    isOpen,
+    currentStep,
+    nextStep,
+    prevStep,
+    completeOnboarding,
+    skipOnboarding,
+  } = useOnboardingStore()
+  const { providers } = useProvidersStore()
+  const { defaultModel } = useModelsStore()
+
+  const stepId = ONBOARDING_STEPS[currentStep]
+  const completedSteps = ONBOARDING_STEPS.slice(0, currentStep)
+
+  const canProceed = (): boolean => {
+    switch (stepId) {
+      case 'api-key':
+        return providers.some((p) => p.configured)
+      case 'model':
+        return defaultModel !== ''
+      default:
+        return true
+    }
+  }
+
+  const renderStep = () => {
+    switch (stepId) {
+      case 'welcome':
+        return <WelcomeStep />
+      case 'api-key':
+        return <ApiKeyStep />
+      case 'model':
+        return <ModelStep />
+      case 'preferences':
+        return <PreferencesStep />
+      case 'complete':
+        return <CompleteStep />
+      default:
+        return <WelcomeStep />
+    }
+  }
+
+  const isFirstStep = currentStep === 0
+  const isLastStep = stepId === 'complete'
+
+  // Empty close handler — wizard must be completed or skipped
+  const handleClose = () => {}
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={handleClose}
+      size="xl"
+      closeOnBackdrop={false}
+      closeOnEscape={false}
+    >
+      <DialogHeader
+        title="Setup Wizard"
+        subtitle={getStepSubtitle(stepId)}
+        icon={<Rocket className="h-5 w-5 text-accent-500" />}
+        onClose={handleClose}
+      >
+        <DialogStepper
+          steps={WIZARD_STEPS}
+          currentStep={stepId}
+          completedSteps={completedSteps}
+          variant="compact"
+          className="mr-4"
+        />
+      </DialogHeader>
+
+      <DialogContent scrollable maxHeight="max-h-[65vh]">
+        {renderStep()}
+      </DialogContent>
+
+      <DialogFooter
+        leftContent={
+          isFirstStep ? (
+            <button
+              onClick={skipOnboarding}
+              className="text-sm text-zinc-500 transition-colors hover:text-zinc-300"
+            >
+              Skip for now
+            </button>
+          ) : (
+            <DialogButton variant="ghost" onClick={prevStep}>
+              Back
+            </DialogButton>
+          )
+        }
+      >
+        {isLastStep ? (
+          <DialogButton variant="primary" onClick={completeOnboarding}>
+            Get Started
+          </DialogButton>
+        ) : (
+          <DialogButton
+            variant="primary"
+            onClick={nextStep}
+            disabled={!canProceed()}
+          >
+            Continue
+          </DialogButton>
+        )}
+      </DialogFooter>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/dialogs/OnboardingWizard/steps/ApiKeyStep.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/steps/ApiKeyStep.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'react'
+import { Eye, EyeOff, Save, Loader2, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useProvidersStore } from '../../../../stores/providers'
+import { useModelsStore } from '../../../../stores/models'
+import { cn } from '../../../../lib/utils'
+
+const TOP_PROVIDERS = ['openai', 'claude', 'google', 'groq']
+
+const PROVIDER_LABELS: Record<string, string> = {
+  openai: 'OpenAI',
+  claude: 'Anthropic / Claude',
+  google: 'Google AI',
+  groq: 'Groq',
+}
+
+export function ApiKeyStep() {
+  const { providers, refresh, update, remove } = useProvidersStore()
+  const { refresh: refreshModels } = useModelsStore()
+  const [editValues, setEditValues] = useState<Record<string, string>>({})
+  const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set())
+  const [saving, setSaving] = useState<string | null>(null)
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const topProviders = providers.filter((p) => TOP_PROVIDERS.includes(p.name))
+  const configuredCount = topProviders.filter((p) => p.configured).length
+
+  const handleSave = async (name: string) => {
+    const value = editValues[name]
+    if (!value?.trim()) return
+
+    setSaving(name)
+    try {
+      await update(name, value.trim())
+      setEditValues((prev) => {
+        const next = { ...prev }
+        delete next[name]
+        return next
+      })
+      setVisibleKeys((prev) => {
+        const next = new Set(prev)
+        next.delete(name)
+        return next
+      })
+      refreshModels()
+      toast.success(`${PROVIDER_LABELS[name] || name} key saved`)
+    } catch {
+      toast.error(`Failed to save ${PROVIDER_LABELS[name] || name} key`)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const handleDelete = async (name: string) => {
+    try {
+      await remove(name)
+      setEditValues((prev) => {
+        const next = { ...prev }
+        delete next[name]
+        return next
+      })
+      refreshModels()
+      toast.success(`${PROVIDER_LABELS[name] || name} key removed`)
+    } catch {
+      toast.error(`Failed to remove ${PROVIDER_LABELS[name] || name} key`)
+    }
+  }
+
+  const toggleVisibility = (name: string) => {
+    setVisibleKeys((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) {
+        next.delete(name)
+      } else {
+        next.add(name)
+      }
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold text-zinc-100">Connect an AI Provider</h3>
+        <p className="mt-1 text-sm text-zinc-400">
+          You need at least one API key to use CachiBot.
+          {configuredCount > 0 && (
+            <span className="ml-1 text-green-400">
+              {configuredCount} provider{configuredCount > 1 ? 's' : ''} configured.
+            </span>
+          )}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {topProviders.map((provider) => {
+          const inputValue = editValues[provider.name] ?? ''
+          const isVisible = visibleKeys.has(provider.name)
+          const isSaving = saving === provider.name
+          const label = PROVIDER_LABELS[provider.name] || provider.name
+
+          return (
+            <div
+              key={provider.name}
+              className="rounded-lg border border-zinc-800 bg-zinc-800/50 p-4 space-y-3"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <h4 className="font-medium text-zinc-200">{label}</h4>
+                  <span
+                    className={cn(
+                      'inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium',
+                      provider.configured
+                        ? 'bg-green-500/20 text-green-400'
+                        : 'bg-zinc-700 text-zinc-400'
+                    )}
+                  >
+                    {provider.configured ? 'Active' : 'Not set'}
+                  </span>
+                </div>
+                {provider.configured && (
+                  <button
+                    onClick={() => handleDelete(provider.name)}
+                    className="rounded p-1 text-zinc-400 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                    title="Remove key"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+
+              {provider.configured && !(provider.name in editValues) && (
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 rounded-lg border border-zinc-700 bg-zinc-700/50 px-3 py-2 font-mono text-sm text-zinc-400">
+                    {isVisible
+                      ? provider.masked_value
+                      : provider.masked_value.replace(/./g, '*').slice(0, 20) + '****'}
+                  </div>
+                  <button
+                    onClick={() => toggleVisibility(provider.name)}
+                    className="rounded p-2 text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-300"
+                  >
+                    {isVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <input
+                  type={isVisible ? 'text' : 'password'}
+                  value={inputValue}
+                  onChange={(e) =>
+                    setEditValues((prev) => ({ ...prev, [provider.name]: e.target.value }))
+                  }
+                  placeholder={provider.configured ? 'Update API key...' : 'Enter API key...'}
+                  className="h-10 flex-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 font-mono text-sm text-zinc-100 outline-none transition-colors focus:border-accent-500"
+                />
+                <button
+                  onClick={() => toggleVisibility(provider.name)}
+                  className="rounded-lg border border-zinc-700 px-3 text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-300"
+                >
+                  {isVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+                <button
+                  onClick={() => handleSave(provider.name)}
+                  disabled={!inputValue.trim() || isSaving}
+                  className="flex items-center gap-1.5 rounded-lg bg-accent-600 px-4 text-sm font-medium text-white transition-colors hover:bg-accent-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isSaving ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Save className="h-4 w-4" />
+                  )}
+                  Save
+                </button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <p className="text-xs text-zinc-500">
+        More providers available in Settings &gt; API Keys after setup.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/dialogs/OnboardingWizard/steps/CompleteStep.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/steps/CompleteStep.tsx
@@ -1,0 +1,62 @@
+import { Check } from 'lucide-react'
+import { useProvidersStore } from '../../../../stores/providers'
+import { useModelsStore } from '../../../../stores/models'
+import { useUIStore } from '../../../../stores/ui'
+
+const PROVIDER_LABELS: Record<string, string> = {
+  openai: 'OpenAI',
+  claude: 'Anthropic / Claude',
+  google: 'Google AI',
+  groq: 'Groq',
+  grok: 'Grok (xAI)',
+  openrouter: 'OpenRouter',
+  moonshot: 'Moonshot',
+  ollama: 'Ollama',
+  lmstudio: 'LM Studio',
+}
+
+export function CompleteStep() {
+  const { providers } = useProvidersStore()
+  const { defaultModel } = useModelsStore()
+  const { theme, accentColor } = useUIStore()
+
+  const configuredProviders = providers
+    .filter((p) => p.configured)
+    .map((p) => PROVIDER_LABELS[p.name] || p.name)
+
+  return (
+    <div className="flex flex-col items-center py-8 text-center">
+      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-green-500/20">
+        <Check className="h-10 w-10 text-green-400" />
+      </div>
+
+      <h2 className="text-2xl font-bold text-zinc-100">You're All Set!</h2>
+      <p className="mt-2 max-w-md text-zinc-400">
+        CachiBot is configured and ready to use. Here's a summary of your setup:
+      </p>
+
+      <div className="mt-6 w-full max-w-sm space-y-3 text-left">
+        {configuredProviders.length > 0 && (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-800/50 p-3">
+            <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Providers</p>
+            <p className="mt-1 text-sm text-zinc-200">{configuredProviders.join(', ')}</p>
+          </div>
+        )}
+
+        {defaultModel && (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-800/50 p-3">
+            <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Default Model</p>
+            <p className="mt-1 font-mono text-sm text-zinc-200">{defaultModel}</p>
+          </div>
+        )}
+
+        <div className="rounded-lg border border-zinc-800 bg-zinc-800/50 p-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-zinc-500">Appearance</p>
+          <p className="mt-1 text-sm text-zinc-200">
+            {theme.charAt(0).toUpperCase() + theme.slice(1)} theme, {accentColor} accent
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dialogs/OnboardingWizard/steps/ModelStep.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/steps/ModelStep.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+import { useModelsStore } from '../../../../stores/models'
+import { ModelSelect } from '../../../common/ModelSelect'
+
+export function ModelStep() {
+  const { defaultModel, updateDefaultModel, refresh } = useModelsStore()
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const handleChange = async (model: string) => {
+    if (model) {
+      await updateDefaultModel(model)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold text-zinc-100">Choose a Default Model</h3>
+        <p className="mt-1 text-sm text-zinc-400">
+          This model will be used for new bots unless you specify a different one.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-zinc-300">Default Model</label>
+        <ModelSelect
+          value={defaultModel}
+          onChange={handleChange}
+          placeholder="Select a model..."
+          className="w-full"
+        />
+      </div>
+
+      {defaultModel && (
+        <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-3">
+          <p className="text-sm text-green-400">
+            Selected: <span className="font-mono text-xs">{defaultModel}</span>
+          </p>
+        </div>
+      )}
+
+      <p className="text-xs text-zinc-500">
+        You can change this anytime in Settings &gt; Models.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/dialogs/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/steps/PreferencesStep.tsx
@@ -1,0 +1,128 @@
+import { Sun, Moon, Monitor } from 'lucide-react'
+import { useUIStore, type Theme, type AccentColor, accentColors } from '../../../../stores/ui'
+import { cn } from '../../../../lib/utils'
+
+const themeOptions: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
+
+const colorOptions = Object.entries(accentColors) as [AccentColor, (typeof accentColors)[AccentColor]][]
+
+export function PreferencesStep() {
+  const { theme, setTheme, accentColor, setAccentColor, showThinking, setShowThinking, showCost, setShowCost } =
+    useUIStore()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold text-zinc-100">Personalize Your Experience</h3>
+        <p className="mt-1 text-sm text-zinc-400">
+          Customize how CachiBot looks and feels.
+        </p>
+      </div>
+
+      {/* Theme */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-zinc-300">Color Theme</label>
+        <div className="flex gap-2">
+          {themeOptions.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => setTheme(option.value)}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-2 rounded-lg border py-3 transition-all',
+                theme === option.value
+                  ? 'border-accent-500 bg-accent-500/20 text-accent-400'
+                  : 'border-zinc-700 bg-zinc-800 text-zinc-300 hover:border-zinc-600'
+              )}
+            >
+              <option.icon className="h-4 w-4" />
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Accent Color */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-zinc-300">Accent Color</label>
+        <div className="grid grid-cols-4 gap-2">
+          {colorOptions.map(([value, { name, palette }]) => (
+            <button
+              key={value}
+              onClick={() => setAccentColor(value)}
+              className={cn(
+                'flex items-center gap-2 rounded-lg border p-3 transition-all',
+                accentColor === value
+                  ? 'border-2 ring-1 ring-offset-1 ring-offset-zinc-900'
+                  : 'border-zinc-700 hover:border-zinc-600'
+              )}
+              style={{
+                borderColor: accentColor === value ? palette[500] : undefined,
+                // @ts-expect-error - Tailwind CSS variable
+                '--tw-ring-color': accentColor === value ? palette[500] : undefined,
+              }}
+            >
+              <div className="h-5 w-5 rounded-full" style={{ backgroundColor: palette[500] }} />
+              <span className="text-sm text-zinc-300">{name}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Display toggles */}
+      <div className="space-y-4">
+        <label className="block text-sm font-medium text-zinc-300">Display Options</label>
+        <ToggleItem
+          label="Show Thinking Process"
+          description="Display the AI's reasoning and thought process"
+          checked={showThinking}
+          onChange={setShowThinking}
+        />
+        <ToggleItem
+          label="Show Token Costs"
+          description="Display estimated costs for API calls"
+          checked={showCost}
+          onChange={setShowCost}
+        />
+      </div>
+    </div>
+  )
+}
+
+function ToggleItem({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-800/50 p-3">
+      <div>
+        <p className="text-sm font-medium text-zinc-200">{label}</p>
+        <p className="text-xs text-zinc-500">{description}</p>
+      </div>
+      <button
+        onClick={() => onChange(!checked)}
+        className={cn(
+          'relative h-6 w-11 rounded-full transition-colors',
+          checked ? 'bg-accent-600' : 'bg-zinc-700'
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-1 h-4 w-4 rounded-full bg-white transition-transform',
+            checked ? 'left-6' : 'left-1'
+          )}
+        />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/dialogs/OnboardingWizard/steps/WelcomeStep.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/steps/WelcomeStep.tsx
@@ -1,0 +1,48 @@
+import { Bot, Sparkles, Key, Palette } from 'lucide-react'
+
+export function WelcomeStep() {
+  return (
+    <div className="flex flex-col items-center py-8 text-center">
+      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-accent-600/20">
+        <Bot className="h-10 w-10 text-accent-500" />
+      </div>
+
+      <h2 className="text-2xl font-bold text-zinc-100">Welcome to CachiBot</h2>
+      <p className="mt-2 max-w-md text-zinc-400">
+        Your security-focused AI agent platform. Let's get you set up in a few quick steps.
+      </p>
+
+      <div className="mt-8 grid w-full max-w-sm gap-3">
+        <div className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-800/50 p-3 text-left">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/20">
+            <Key className="h-4 w-4 text-blue-400" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-zinc-200">Connect a Provider</p>
+            <p className="text-xs text-zinc-500">Add an API key to get started</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-800/50 p-3 text-left">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/20">
+            <Sparkles className="h-4 w-4 text-purple-400" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-zinc-200">Pick a Model</p>
+            <p className="text-xs text-zinc-500">Choose your default AI model</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-800/50 p-3 text-left">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-orange-500/20">
+            <Palette className="h-4 w-4 text-orange-400" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-zinc-200">Personalize</p>
+            <p className="text-xs text-zinc-500">Set your theme and preferences</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dialogs/ToolConfigDialog.tsx
+++ b/frontend/src/components/dialogs/ToolConfigDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { X, Save, RotateCcw } from 'lucide-react'
+import { X, Save, RotateCcw, Plus, Trash2, Eye, EyeOff, FolderOpen, FileText, MapPin, Link, Code, Check } from 'lucide-react'
 import { useBotStore } from '../../stores/bots'
 import type { Tool, ToolConfigs, ConfigParam } from '../../types'
 import { cn } from '../../lib/utils'
@@ -63,6 +63,17 @@ export function ToolConfigDialog({ tool, botId, currentConfigs, isOpen, onClose 
 
   const updateValue = (name: string, value: unknown) => {
     setValues((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const [revealedSecrets, setRevealedSecrets] = useState<Set<string>>(new Set())
+
+  const toggleSecretVisibility = (name: string) => {
+    setRevealedSecrets((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
   }
 
   if (!isOpen) return null
@@ -167,7 +178,337 @@ export function ToolConfigDialog({ tool, botId, currentConfigs, isOpen, onClose 
               type="text"
               value={strValue}
               onChange={(e) => updateValue(param.name, e.target.value)}
-              className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-cachi-500"
+              placeholder={param.placeholder}
+              className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500"
+            />
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'secret': {
+        const strValue = String(value ?? param.default ?? '')
+        const isRevealed = revealedSecrets.has(param.name)
+        return (
+          <div key={param.name} className="space-y-2">
+            <label className="text-sm font-medium text-zinc-300">
+              {param.displayName || param.name}
+            </label>
+            <div className="relative">
+              <input
+                type={isRevealed ? 'text' : 'password'}
+                value={strValue}
+                onChange={(e) => updateValue(param.name, e.target.value)}
+                placeholder={param.placeholder ?? 'Enter secret...'}
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 pr-10 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500"
+              />
+              <button
+                type="button"
+                onClick={() => toggleSecretVisibility(param.name)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300"
+              >
+                {isRevealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'text': {
+        const strValue = String(value ?? param.default ?? '')
+        return (
+          <div key={param.name} className="space-y-2">
+            <label className="text-sm font-medium text-zinc-300">
+              {param.displayName || param.name}
+            </label>
+            <textarea
+              value={strValue}
+              onChange={(e) => updateValue(param.name, e.target.value)}
+              rows={param.rows ?? 4}
+              placeholder={param.placeholder}
+              className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500 resize-y"
+            />
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'path': {
+        const strValue = String(value ?? param.default ?? '')
+        const pathIcon = param.pathType === 'directory' ? FolderOpen
+          : param.pathType === 'file' ? FileText
+          : MapPin
+        const PathIcon = pathIcon
+        return (
+          <div key={param.name} className="space-y-2">
+            <label className="text-sm font-medium text-zinc-300">
+              {param.displayName || param.name}
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">
+                <PathIcon className="h-4 w-4" />
+              </span>
+              <input
+                type="text"
+                value={strValue}
+                onChange={(e) => updateValue(param.name, e.target.value)}
+                placeholder={param.placeholder ?? (param.pathType === 'directory' ? '/path/to/directory' : '/path/to/file')}
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 pl-9 pr-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500 font-mono"
+              />
+            </div>
+            {param.pathType && (
+              <span className="inline-block rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400 border border-zinc-700">
+                {param.pathType}
+              </span>
+            )}
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'string[]':
+      case 'number[]': {
+        const isNumeric = param.type === 'number[]'
+        const items = Array.isArray(value) ? (value as (string | number)[]) : (Array.isArray(param.default) ? (param.default as (string | number)[]) : [])
+        const canAdd = param.maxItems === undefined || items.length < param.maxItems
+        const canRemove = param.minItems === undefined || items.length > param.minItems
+
+        const updateItems = (newItems: (string | number)[]) => {
+          updateValue(param.name, newItems)
+        }
+
+        return (
+          <div key={param.name} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-zinc-300">
+                {param.displayName || param.name}
+              </label>
+              <span className="text-xs text-zinc-500">
+                {items.length}{param.maxItems !== undefined ? ` / ${param.maxItems}` : ''} items
+              </span>
+            </div>
+            <div className="space-y-2">
+              {items.map((item, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <input
+                    type={isNumeric ? 'number' : 'text'}
+                    value={item}
+                    onChange={(e) => {
+                      const newItems = [...items]
+                      newItems[i] = isNumeric ? Number(e.target.value) : e.target.value
+                      updateItems(newItems)
+                    }}
+                    placeholder={param.itemPlaceholder}
+                    className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500"
+                  />
+                  <button
+                    onClick={() => {
+                      if (!canRemove) return
+                      updateItems(items.filter((_, j) => j !== i))
+                    }}
+                    disabled={!canRemove}
+                    className="rounded-lg p-1.5 text-zinc-500 hover:bg-zinc-800 hover:text-red-400 disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => {
+                if (!canAdd) return
+                updateItems([...items, isNumeric ? 0 : ''])
+              }}
+              disabled={!canAdd}
+              className="flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700 px-3 py-1.5 text-xs text-zinc-400 hover:border-cachi-500 hover:text-cachi-400 disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add item
+            </button>
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'map': {
+        const entries = Array.isArray(value)
+          ? (value as [string, string][])
+          : (Array.isArray(param.default) ? (param.default as [string, string][]) : [])
+        const canAdd = param.maxItems === undefined || entries.length < param.maxItems
+
+        const updateEntries = (newEntries: [string, string][]) => {
+          updateValue(param.name, newEntries)
+        }
+
+        return (
+          <div key={param.name} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-zinc-300">
+                {param.displayName || param.name}
+              </label>
+              <span className="text-xs text-zinc-500">
+                {entries.length}{param.maxItems !== undefined ? ` / ${param.maxItems}` : ''} entries
+              </span>
+            </div>
+            <div className="space-y-2">
+              {entries.map(([k, v], i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={k}
+                    onChange={(e) => {
+                      const newEntries = [...entries] as [string, string][]
+                      newEntries[i] = [e.target.value, v]
+                      updateEntries(newEntries)
+                    }}
+                    placeholder={param.keyPlaceholder ?? 'Key'}
+                    className="w-2/5 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500"
+                  />
+                  <input
+                    type="text"
+                    value={v}
+                    onChange={(e) => {
+                      const newEntries = [...entries] as [string, string][]
+                      newEntries[i] = [k, e.target.value]
+                      updateEntries(newEntries)
+                    }}
+                    placeholder={param.valuePlaceholder ?? 'Value'}
+                    className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500"
+                  />
+                  <button
+                    onClick={() => updateEntries(entries.filter((_, j) => j !== i))}
+                    className="rounded-lg p-1.5 text-zinc-500 hover:bg-zinc-800 hover:text-red-400"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => {
+                if (!canAdd) return
+                updateEntries([...entries, ['', '']])
+              }}
+              disabled={!canAdd}
+              className="flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700 px-3 py-1.5 text-xs text-zinc-400 hover:border-cachi-500 hover:text-cachi-400 disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add entry
+            </button>
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'multiselect': {
+        const selected = Array.isArray(value) ? (value as string[]) : (Array.isArray(param.default) ? (param.default as string[]) : [])
+        const options = param.options || []
+
+        const toggleOption = (opt: string) => {
+          const next = selected.includes(opt)
+            ? selected.filter((s) => s !== opt)
+            : [...selected, opt]
+          updateValue(param.name, next)
+        }
+
+        return (
+          <div key={param.name} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-zinc-300">
+                {param.displayName || param.name}
+              </label>
+              <span className="text-xs text-zinc-500">
+                {selected.length} / {options.length} selected
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {options.map((opt) => {
+                const isSelected = selected.includes(opt)
+                return (
+                  <button
+                    key={opt}
+                    onClick={() => toggleOption(opt)}
+                    className={cn(
+                      'flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs transition-colors',
+                      isSelected
+                        ? 'border-cachi-500 bg-cachi-500/15 text-cachi-300'
+                        : 'border-zinc-700 bg-zinc-800 text-zinc-400 hover:border-zinc-600 hover:text-zinc-300'
+                    )}
+                  >
+                    {isSelected && <Check className="h-3 w-3" />}
+                    {opt}
+                  </button>
+                )
+              })}
+            </div>
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'url': {
+        const strValue = String(value ?? param.default ?? '')
+        return (
+          <div key={param.name} className="space-y-2">
+            <label className="text-sm font-medium text-zinc-300">
+              {param.displayName || param.name}
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">
+                <Link className="h-4 w-4" />
+              </span>
+              <input
+                type="url"
+                value={strValue}
+                onChange={(e) => updateValue(param.name, e.target.value)}
+                placeholder={param.placeholder ?? 'https://...'}
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 pl-9 pr-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500"
+              />
+            </div>
+            {param.description && (
+              <p className="text-xs text-zinc-500">{param.description}</p>
+            )}
+          </div>
+        )
+      }
+
+      case 'code': {
+        const strValue = String(value ?? param.default ?? '')
+        return (
+          <div key={param.name} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-zinc-300">
+                {param.displayName || param.name}
+              </label>
+              {param.language && (
+                <span className="flex items-center gap-1 rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400 border border-zinc-700">
+                  <Code className="h-3 w-3" />
+                  {param.language}
+                </span>
+              )}
+            </div>
+            <textarea
+              value={strValue}
+              onChange={(e) => updateValue(param.name, e.target.value)}
+              rows={param.rows ?? 6}
+              placeholder={param.placeholder}
+              spellCheck={false}
+              className="w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-cachi-500 resize-y font-mono leading-relaxed"
             />
             {param.description && (
               <p className="text-xs text-zinc-500">{param.description}</p>
@@ -199,7 +540,7 @@ export function ToolConfigDialog({ tool, botId, currentConfigs, isOpen, onClose 
         </div>
 
         {/* Content */}
-        <div className="p-4">
+        <div className="max-h-[60vh] overflow-y-auto p-4">
           {hasConfig ? (
             <div className="space-y-6">
               {configParams.map(renderParam)}

--- a/frontend/src/components/views/AppSettingsView.tsx
+++ b/frontend/src/components/views/AppSettingsView.tsx
@@ -46,6 +46,7 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useUIStore, Theme, AccentColor, accentColors } from '../../stores/ui'
+import { useOnboardingStore } from '../../stores/onboarding'
 import { useConfigStore } from '../../stores/config'
 import { useModelsStore } from '../../stores/models'
 import { useProvidersStore } from '../../stores/providers'
@@ -306,7 +307,39 @@ function GeneralSettings({
           </div>
         </div>
       </Section>
+
+      <SetupWizardButton />
     </>
+  )
+}
+
+function SetupWizardButton() {
+  const { open } = useOnboardingStore()
+
+  const handleRunWizard = () => {
+    // Reset the flag so the wizard can run again, then open it
+    useOnboardingStore.setState({ hasCompletedOnboarding: false })
+    open()
+  }
+
+  return (
+    <Section icon={RefreshCw} title="Setup">
+      <div className="flex items-center justify-between">
+        <div>
+          <h4 className="font-medium text-zinc-800 dark:text-zinc-200">Run Setup Wizard</h4>
+          <p className="text-sm text-zinc-500">
+            Re-run the initial setup to configure API keys, models, and preferences
+          </p>
+        </div>
+        <button
+          onClick={handleRunWizard}
+          className="flex items-center gap-2 rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-500"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Run Wizard
+        </button>
+      </div>
+    </Section>
   )
 }
 

--- a/frontend/src/stores/onboarding.ts
+++ b/frontend/src/stores/onboarding.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+const STEPS = ['welcome', 'api-key', 'model', 'preferences', 'complete'] as const
+export type OnboardingStep = (typeof STEPS)[number]
+
+interface OnboardingState {
+  isOpen: boolean
+  currentStep: number
+  hasCompletedOnboarding: boolean
+
+  // Actions
+  open: () => void
+  close: () => void
+  nextStep: () => void
+  prevStep: () => void
+  completeOnboarding: () => void
+  skipOnboarding: () => void
+}
+
+export { STEPS as ONBOARDING_STEPS }
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      currentStep: 0,
+      hasCompletedOnboarding: false,
+
+      open: () => set({ isOpen: true, currentStep: 0 }),
+      close: () => set({ isOpen: false }),
+      nextStep: () =>
+        set((state) => ({
+          currentStep: Math.min(state.currentStep + 1, STEPS.length - 1),
+        })),
+      prevStep: () =>
+        set((state) => ({
+          currentStep: Math.max(state.currentStep - 1, 0),
+        })),
+      completeOnboarding: () =>
+        set({ isOpen: false, hasCompletedOnboarding: true, currentStep: 0 }),
+      skipOnboarding: () =>
+        set({ isOpen: false, hasCompletedOnboarding: true, currentStep: 0 }),
+    }),
+    {
+      name: 'cachibot-onboarding',
+      partialize: (state) => ({
+        hasCompletedOnboarding: state.hasCompletedOnboarding,
+      }),
+    }
+  )
+)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -543,7 +543,7 @@ export interface ConfigParam {
   name: string
   displayName: string | null
   description: string | null
-  type: 'number' | 'string' | 'boolean' | 'select'
+  type: 'number' | 'string' | 'boolean' | 'select' | 'string[]' | 'number[]' | 'secret' | 'text' | 'path' | 'map' | 'multiselect' | 'url' | 'code'
   default: unknown
   min?: number
   max?: number
@@ -551,6 +551,21 @@ export interface ConfigParam {
   options?: string[]
   unit?: string
   scope: 'global' | 'per_bot' | 'per_call'
+  // Array types (string[], number[])
+  minItems?: number
+  maxItems?: number
+  itemPlaceholder?: string
+  // Secret, text, path types
+  placeholder?: string
+  // Text type
+  rows?: number
+  // Path type
+  pathType?: 'file' | 'directory' | 'any'
+  // Map type
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+  // Code type
+  language?: string
 }
 
 // =============================================================================

--- a/src/cachibot/agent.py
+++ b/src/cachibot/agent.py
@@ -12,9 +12,9 @@ from typing import Any
 from prompture import (
     AgentCallbacks,
     AgentResult,
-    PythonSandbox,
     ToolRegistry,
 )
+from tukuy import PythonSandbox
 from prompture import (
     AsyncAgent as PromptureAgent,
 )

--- a/src/cachibot/api/routes/plugins.py
+++ b/src/cachibot/api/routes/plugins.py
@@ -100,7 +100,7 @@ def _instantiate_for_introspection(cls: type):
     CachiBot custom plugins need a PluginContext; Tukuy built-in plugins don't.
     """
     if issubclass(cls, CachibotPlugin):
-        from prompture import PythonSandbox
+        from tukuy import PythonSandbox
 
         from cachibot.config import Config
         from cachibot.plugins.base import PluginContext

--- a/src/cachibot/config.py
+++ b/src/cachibot/config.py
@@ -70,6 +70,9 @@ class AgentConfig:
 
     # Default to Kimi K2.5 via Moonshot
     model: str = "moonshot/kimi-k2.5"
+    # Cheap/fast model for utility tasks (name gen, questions).
+    # Falls back to main model if empty.
+    utility_model: str = ""
     max_iterations: int = 20
     approve_actions: bool = False
     temperature: float = 0.6  # Moonshot recommends 0.6 for instant mode
@@ -190,6 +193,10 @@ class Config:
         if model := os.getenv("CACHIBOT_MODEL"):
             self.agent.model = model
 
+        # Utility model (cheap/fast for name gen, questions, etc.)
+        if utility_model := os.getenv("CACHIBOT_UTILITY_MODEL"):
+            self.agent.utility_model = utility_model
+
         # Approval mode
         if os.getenv("CACHIBOT_APPROVE", "").lower() in ("1", "true", "yes"):
             self.agent.approve_actions = True
@@ -267,6 +274,8 @@ class Config:
                 self.agent.temperature = agent_data["temperature"]
             if "max_tokens" in agent_data:
                 self.agent.max_tokens = agent_data["max_tokens"]
+            if "utility_model" in agent_data:
+                self.agent.utility_model = agent_data["utility_model"]
 
         if sandbox_data := data.get("sandbox"):
             if "allowed_imports" in sandbox_data:

--- a/src/cachibot/models/websocket.py
+++ b/src/cachibot/models/websocket.py
@@ -114,7 +114,7 @@ class WSMessage(BaseModel):
         """Create a chat message."""
         return cls(
             type=WSMessageType.MESSAGE,
-            payload={"role": role, "content": content, "message_id": message_id},
+            payload={"role": role, "content": content, "messageId": message_id},
         )
 
     @classmethod

--- a/src/cachibot/plugins/base.py
+++ b/src/cachibot/plugins/base.py
@@ -8,7 +8,7 @@ workspace-scoped, capability-gated tool architecture.
 from dataclasses import dataclass, field
 from typing import Any
 
-from prompture import PythonSandbox
+from tukuy import PythonSandbox
 from tukuy.plugins.base import TransformerPlugin
 
 from cachibot.config import Config

--- a/src/cachibot/plugins/python_sandbox.py
+++ b/src/cachibot/plugins/python_sandbox.py
@@ -2,8 +2,9 @@
 Python sandbox plugin — sandboxed python_execute tool with risk analysis.
 """
 
-from prompture import ApprovalRequired, analyze_python
-from prompture import RiskLevel as PromptureRiskLevel
+from prompture import ApprovalRequired
+from tukuy import analyze_python
+from tukuy.analysis.risk_scoring import RiskLevel as AnalysisRiskLevel
 from tukuy.manifest import PluginManifest, PluginRequirements
 from tukuy.skill import ConfigParam, RiskLevel, Skill, skill
 
@@ -78,7 +79,7 @@ class PythonSandboxPlugin(CachibotPlugin):
             # Analyze code first
             analysis = analyze_python(code)
 
-            if analysis.risk_level in (PromptureRiskLevel.HIGH, PromptureRiskLevel.CRITICAL):
+            if analysis.risk_level in (AnalysisRiskLevel.HIGH, AnalysisRiskLevel.CRITICAL):
                 raise ApprovalRequired(
                     tool_name="python_execute",
                     action=f"Execute {analysis.risk_level.value}-risk Python code",

--- a/src/cachibot/services/name_generator.py
+++ b/src/cachibot/services/name_generator.py
@@ -1,16 +1,16 @@
 """Bot name generation service using Prompture."""
 
+import json
 import logging
+import re
 
-from prompture import extract_with_model
+import httpx
+from prompture.aio import get_async_driver_for_model
 from pydantic import BaseModel, Field
 
 from cachibot.config import Config
 
 logger = logging.getLogger(__name__)
-
-# Default model for name generation - use a reliable model for structured output
-DEFAULT_MODEL = "anthropic/claude-3-5-haiku-20241022"
 
 # Fallback names if generation fails (2 human names + 2 creative)
 FALLBACK_NAMES = [
@@ -25,23 +25,100 @@ class NameWithMeaning(BaseModel):
     """A bot name with its meaning."""
 
     name: str = Field(description="The bot name (1-2 words)")
-    meaning: str = Field(description="The meaning or origin of this name, explaining why it's suitable for an AI assistant")
-
-
-class BotNameSuggestions(BaseModel):
-    """Structured output for bot name suggestions."""
-
-    names: list[str] = Field(
-        description="A list of creative, memorable bot names. Each should be 1-2 words, catchy, and suitable for an AI assistant."
+    meaning: str = Field(
+        description="The meaning or origin of this name, explaining why it's suitable for an AI assistant"
     )
 
 
-class BotNamesWithMeanings(BaseModel):
-    """Structured output for bot name suggestions with meanings."""
+def _resolve_utility_model() -> str:
+    """Resolve the model to use for utility tasks."""
+    try:
+        config = Config.load()
+        return config.agent.utility_model or config.agent.model
+    except Exception:
+        return "moonshot/kimi-k2.5"
 
-    names: list[NameWithMeaning] = Field(
-        description="A list of creative bot names with their meanings and significance"
-    )
+
+def _extract_json(text: str) -> dict:
+    """Extract JSON object from model response text."""
+    # Try the whole text first
+    try:
+        return json.loads(text.strip())
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Try to find JSON in code blocks
+    code_block = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+    if code_block:
+        try:
+            return json.loads(code_block.group(1).strip())
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Try to find a JSON object with "names" key anywhere
+    brace_match = re.search(r'\{[^{}]*"names"\s*:\s*\[.*?\]\s*\}', text, re.DOTALL)
+    if brace_match:
+        try:
+            return json.loads(brace_match.group(0))
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Last resort: find any JSON object
+    brace_match = re.search(r"\{.*\}", text, re.DOTALL)
+    if brace_match:
+        try:
+            return json.loads(brace_match.group(0))
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    raise ValueError(f"Could not extract JSON from response: {text[:300]}")
+
+
+async def _chat_completion(prompt: str, model_name: str) -> str:
+    """Call the model's chat completion API directly, handling reasoning models properly."""
+    driver = get_async_driver_for_model(model_name)
+
+    # Get API credentials from the driver
+    api_key = getattr(driver, "api_key", None)
+    base_url = getattr(driver, "base_url", None) or getattr(driver, "api_base", None)
+
+    if not api_key or not base_url:
+        raise ValueError(f"Cannot get API credentials from driver for {model_name}")
+
+    # Strip provider prefix from model name (e.g. "moonshot/kimi-k2.5" -> "kimi-k2.5")
+    bare_model = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data: dict = {
+        "model": bare_model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{base_url.rstrip('/')}/chat/completions",
+            headers=headers,
+            json=data,
+            timeout=120,
+        )
+        response.raise_for_status()
+        resp = response.json()
+
+    message = resp["choices"][0]["message"]
+    content = message.get("content") or ""
+    reasoning = message.get("reasoning_content") or ""
+
+    # Prefer content, fall back to reasoning if content is empty
+    if content.strip():
+        return content
+    if reasoning.strip():
+        return reasoning
+
+    raise ValueError("Model returned empty response (both content and reasoning_content empty)")
 
 
 async def generate_bot_names(
@@ -61,22 +138,18 @@ async def generate_bot_names(
         List of creative bot name suggestions
     """
     if model is None:
-        try:
-            config = Config.load()
-            model = config.agent.model
-        except Exception:
-            model = DEFAULT_MODEL
+        model = _resolve_utility_model()
 
     exclude_set = set(name.lower() for name in (exclude or []))
 
     exclude_clause = ""
     if exclude:
-        exclude_clause = f"\n\nDO NOT use these names (already taken): {', '.join(exclude)}"
+        exclude_clause = f"\nDO NOT use these names (already taken): {', '.join(exclude)}"
 
     human_count = count // 2
     creative_count = count - human_count
 
-    prompt_text = f"""Generate {count} names for a personal AI assistant.
+    prompt = f"""Generate {count} names for a personal AI assistant.
 
 Requirements:
 - {human_count} should be REAL HUMAN FIRST NAMES (like Carlos, Emma, James, Sofia)
@@ -85,24 +158,24 @@ Requirements:
 - Names should feel warm and approachable
 {exclude_clause}
 
-Good examples: Carlos, Sophie, Max, Aria, Chef, Scout, Sage, Coach"""
+Good examples: Carlos, Sophie, Max, Aria, Chef, Scout, Sage, Coach
 
-    instruction = (
-        f"Generate exactly {count} names "
-        f"({human_count} human + {creative_count} creative). Names only, no explanations:"
-    )
+Respond with ONLY a JSON object in this exact format, no other text:
+{{"names": ["Name1", "Name2", "Name3", "Name4"]}}"""
 
     fallback_names = [n for n, _ in FALLBACK_NAMES if n.lower() not in exclude_set][:count]
 
-    result = extract_with_model(
-        BotNameSuggestions,
-        prompt_text,
-        model,
-        instruction_template=instruction,
-        max_retries=3,
-        fallback=BotNameSuggestions(names=fallback_names),
-    )
-    return result.model.names[:count]
+    try:
+        response = await _chat_completion(prompt, model)
+        data = _extract_json(response)
+        names = data.get("names", [])
+        if names:
+            return names[:count]
+        logger.warning("No names in response, using fallbacks")
+        return fallback_names
+    except Exception:
+        logger.exception("Name generation failed, using fallbacks")
+        return fallback_names
 
 
 async def generate_bot_names_with_meanings(
@@ -126,54 +199,39 @@ async def generate_bot_names_with_meanings(
         List of creative bot names with their meanings
     """
     if model is None:
-        try:
-            config = Config.load()
-            model = config.agent.model
-        except Exception:
-            model = DEFAULT_MODEL
+        model = _resolve_utility_model()
 
     exclude_set = set(name.lower() for name in (exclude or []))
 
     exclude_clause = ""
     if exclude:
-        exclude_clause = f"\n\nDO NOT use these names (already taken): {', '.join(exclude)}"
+        exclude_clause = f"\nDO NOT use these names (already taken): {', '.join(exclude)}"
 
     context_clause = ""
     if purpose:
-        context_clause = f"\n\n## What this bot does:\n{purpose}\n"
+        context_clause += f"\nWhat this bot does: {purpose}"
     if personality:
-        context_clause += f"\n## Personality style: {personality}\n"
+        context_clause += f"\nPersonality style: {personality}"
 
     human_count = count // 2
     creative_count = count - human_count
 
-    prompt_text = f"""Generate {count} names for a personal AI assistant, each with a brief explanation.
+    prompt = f"""Generate {count} names for a personal AI assistant, each with a brief meaning.
 {context_clause}
-## IMPORTANT - Name Types Required:
-1. Generate {human_count} REAL HUMAN FIRST NAMES (like Carlos, Emma, James, Sofia, Marcus, Lucia)
-   - Choose names that feel warm and approachable
-   - Pick names from different cultures that match the bot's purpose
-   - These should be actual names people have, not made-up words
 
-2. Generate {creative_count} CREATIVE NAMES related to what the bot does
-   - These should relate to the bot's purpose (e.g., a cooking bot could be "Chef", "Basil", "Saffron")
-   - Avoid generic tech names like "Nova", "Echo", "Pixel", "Vector", "Atlas"
-   - Think of words related to the domain: tools, concepts, or playful references
+Name types required:
+- {human_count} REAL HUMAN FIRST NAMES (warm, approachable, from different cultures)
+- {creative_count} CREATIVE NAMES related to the bot's purpose
+- Avoid generic tech names like Nova, Echo, Pixel, Vector, Atlas
 {exclude_clause}
 
-## Examples by purpose:
-- Cooking bot: "Carlos" (friendly chef), "Miso" (Japanese ingredient), "Julia" (like Julia Child)
-- Fitness bot: "Marcus" (strong Roman name), "Coach", "Rocky"
-- Coding bot: "Ada" (Ada Lovelace), "Linus" (Linus Torvalds), "Bug" (playful)
-- Writing bot: "Ernest" (Hemingway), "Quill", "Maya" (Angelou)
+Examples by purpose:
+- Cooking: "Carlos" (friendly chef), "Miso" (Japanese ingredient), "Julia" (Julia Child)
+- Fitness: "Marcus" (strong Roman name), "Coach", "Rocky"
+- Coding: "Ada" (Ada Lovelace), "Linus" (Torvalds), "Bug" (playful)
 
-Keep meanings SHORT (1 sentence max). Focus on why the name fits THIS specific bot."""
-
-    instruction = (
-        f"Generate exactly {count} names "
-        f"({human_count} real human names + {creative_count} creative/domain names). "
-        "Keep meanings brief:"
-    )
+Respond with ONLY a JSON object in this exact format, no other text:
+{{"names": [{{"name": "ExampleName", "meaning": "Brief reason this name fits"}}, ...]}}"""
 
     fallback_names = [
         NameWithMeaning(name=name, meaning=meaning)
@@ -181,12 +239,23 @@ Keep meanings SHORT (1 sentence max). Focus on why the name fits THIS specific b
         if name.lower() not in exclude_set
     ][:count]
 
-    result = extract_with_model(
-        BotNamesWithMeanings,
-        prompt_text,
-        model,
-        instruction_template=instruction,
-        max_retries=3,
-        fallback=BotNamesWithMeanings(names=fallback_names),
-    )
-    return result.model.names[:count]
+    try:
+        response = await _chat_completion(prompt, model)
+        data = _extract_json(response)
+        raw_names = data.get("names", [])
+        names = []
+        for item in raw_names:
+            if isinstance(item, dict) and "name" in item:
+                names.append(
+                    NameWithMeaning(
+                        name=item["name"],
+                        meaning=item.get("meaning", "A great name for your bot"),
+                    )
+                )
+        if names:
+            return names[:count]
+        logger.warning("No names parsed from response, using fallbacks")
+        return fallback_names
+    except Exception:
+        logger.exception("Name generation with meanings failed, using fallbacks")
+        return fallback_names


### PR DESCRIPTION
Add a comprehensive architecture.md describing Prompture, Tukuy, and CachiBot integration and dataflow. Extend ToolConfigDialog to support many new ConfigParam types (secret, text, path, string[]/number[], map, multiselect, url, code), add UI features (secret reveal toggle, add/remove items, icons, placeholders, descriptions, scrollable content area), and import necessary lucide icons. Update frontend types (ConfigParam) to include new type variants and related fields (minItems/maxItems, placeholders, rows, pathType, key/value placeholders, language) so the UI and plugin metadata can express richer configuration options.