### PR TITLE
Use AgentResult.run_usage for usage stats

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -193,6 +193,10 @@ export function useWebSocket() {
               iterations: payload.iterations,
               elapsedMs: payload.elapsedMs,
               tokensPerSecond: payload.tokensPerSecond,
+              callCount: payload.callCount,
+              errors: payload.errors,
+              perModel: payload.perModel,
+              latencyStats: payload.latencyStats,
             })
           }
           break

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -82,6 +82,14 @@ export interface MessageMetadata {
   tokens?: number
   cost?: number
   iterations?: number
+  promptTokens?: number
+  completionTokens?: number
+  elapsedMs?: number
+  tokensPerSecond?: number
+  callCount?: number
+  errors?: number
+  perModel?: Record<string, { tokens: number; cost: number }>
+  latencyStats?: Record<string, number>
 }
 
 export interface ChatMessage {
@@ -372,6 +380,10 @@ export interface UsagePayload {
   iterations: number
   elapsedMs: number
   tokensPerSecond: number
+  callCount: number
+  errors: number
+  perModel: Record<string, { tokens: number; cost: number }>
+  latencyStats: Record<string, number>
 }
 
 export interface PlatformMessagePayload {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ cachibot = "cachibot.cli:app"
 cachi = "cachibot.cli:app"
 
 [project.urls]
-Homepage = "https://cachibot.dev"
-Documentation = "https://cachibot.dev/docs"
+Homepage = "https://cachibot.com"
+Documentation = "https://cachibot.com/docs"
 Repository = "https://github.com/jhd3197/cachibot"
 Issues = "https://github.com/jhd3197/cachibot/issues"
 

--- a/src/cachibot/models/websocket.py
+++ b/src/cachibot/models/websocket.py
@@ -73,6 +73,12 @@ class UsagePayload(BaseModel):
     completion_tokens: int = Field(default=0)
     total_cost: float = Field(default=0.0)
     iterations: int = Field(default=0)
+    elapsed_ms: float = Field(default=0.0)
+    tokens_per_second: float = Field(default=0.0)
+    call_count: int = Field(default=0)
+    errors: int = Field(default=0)
+    per_model: dict = Field(default_factory=dict)
+    latency_stats: dict = Field(default_factory=dict)
 
 
 class ErrorPayload(BaseModel):
@@ -135,6 +141,10 @@ class WSMessage(BaseModel):
         completion_tokens: int = 0,
         elapsed_ms: float = 0.0,
         tokens_per_second: float = 0.0,
+        call_count: int = 0,
+        errors: int = 0,
+        per_model: dict | None = None,
+        latency_stats: dict | None = None,
     ) -> "WSMessage":
         """Create a usage message."""
         return cls(
@@ -147,6 +157,10 @@ class WSMessage(BaseModel):
                 "iterations": iterations,
                 "elapsedMs": elapsed_ms,
                 "tokensPerSecond": tokens_per_second,
+                "callCount": call_count,
+                "errors": errors,
+                "perModel": per_model or {},
+                "latencyStats": latency_stats or {},
             },
         )
 


### PR DESCRIPTION
Switch usage reporting to read from AgentResult.run_usage and propagate new metrics across the stack. The agent.run() API now returns an AgentResult (not a plain string) and no longer stores a _last_result or exposes get_usage(); a conversation property was added. WebSocket handling captures the final AgentResult from the stream and sends detailed usage (callCount, errors, perModel, latencyStats). CLI, message processor, frontend types/hooks, and websocket models were updated to consume the new run_usage fields and include them in saved metadata and UI messages. This centralizes usage data and adds richer telemetry (timing, per-model breakdowns, call/error counts).