### PR TITLE
Add setup step & creation context analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ CachiBot is a security-focused AI agent that uses the Prompture library for stru
 ### Backend Development
 ```bash
 pip install -e ".[dev]"          # Install with dev dependencies
-cachibot-server                   # Start API server (port 6392)
+cachibot server                   # Start API server (port 6392)
 cachibot "your prompt"            # Run single prompt via CLI
 cachibot -i                       # Interactive mode
 pytest                            # Run all tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN pip install --no-cache-dir -e .
 EXPOSE 6392
 
 # Run the server
-CMD ["cachibot-server"]
+CMD ["cachibot server"]

--- a/README.md
+++ b/README.md
@@ -1,56 +1,68 @@
-<p align="center">
-  <img width="800"  alt="CachiBot" src="https://github.com/user-attachments/assets/0855ecf4-c0ec-4d81-ad2a-3887d3688cb1" />
-</p>
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/0855ecf4-c0ec-4d81-ad2a-3887d3688cb1" alt="CachiBot" width="800" />
 
-<h1 align="center">CachiBot</h1>
+  <h1>CachiBot</h1>
 
-<p align="center">
-  <strong>The Armored AI Agent</strong>
-</p>
+  <p><strong>The Armored AI Agent</strong></p>
+  <p><em>Visual. Transparent. Secure.</em></p>
 
-<p align="center">
-  <em>Visual. Transparent. Secure.</em>
-</p>
+  <p>
+    <a href="docs/README.es.md">Español</a> ·
+    <a href="docs/README.zh-CN.md">中文版</a> ·
+    <a href="docs/README.pt.md">Português</a>
+  </p>
 
-<p align="center">
-  <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/v/cachibot.svg" alt="PyPI"></a>
-  <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/dm/cachibot.svg" alt="Downloads"></a>
-  <a href="https://github.com/jhd3197/cachibot/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License"></a>
-  <a href="https://python.org"><img src="https://img.shields.io/badge/Python-3.10+-blue.svg" alt="Python"></a>
-  <a href="https://react.dev"><img src="https://img.shields.io/badge/React-18+-61DAFB.svg" alt="React"></a>
-</p>
+  <p>
+    <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
+    <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS" />
+    <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux" />
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/v/cachibot.svg" alt="PyPI" /></a>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/dm/cachibot.svg" alt="Downloads" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License" /></a>
+    <a href="https://python.org"><img src="https://img.shields.io/badge/Python-3.10+-blue.svg" alt="Python" /></a>
+    <a href="https://react.dev"><img src="https://img.shields.io/badge/React-18+-61DAFB.svg" alt="React" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/stargazers"><img src="https://img.shields.io/github/stars/jhd3197/CachiBot?style=social" alt="Stars" /></a>
+    <a href="https://discord.gg/V9bKwYVJ"><img src="https://img.shields.io/discord/1470624345188732992?label=Discord&logo=discord&logoColor=white&color=5865F2" alt="Discord" /></a>
+  </p>
+
+  <p>
+    A visual AI agent platform with full transparency. Named after the Venezuelan <em>cachicamo</em> (armadillo) — built to be armored, auditable, and yours to control.
+  </p>
+
+  <p>
+    <a href="#-quick-start">Quick Start</a> ·
+    <a href="#-features">Features</a> ·
+    <a href="#-architecture">Architecture</a> ·
+    <a href="#-security">Security</a> ·
+    <a href="#-contributing">Contributing</a> ·
+    <a href="https://discord.gg/V9bKwYVJ">Discord</a>
+  </p>
+
+</div>
 
 ---
 
-**CachiBot** is a visual AI agent platform with full transparency. Named after the Venezuelan *cachicamo* (armadillo), it's built to be armored, auditable, and yours to control.
-
 ## Why Visual?
 
-Most AI agent tools run in terminals where you can't see what's happening. That's a security nightmare.
+Most AI agents run in terminals where you can't see what's happening. That's a security nightmare.
 
-**The problem with CLI-based agents:**
-- You can't see what the agent is doing in real-time
-- No visibility into running tasks or jobs
-- No way to monitor multiple bots simultaneously
-- Actions happen in a black box
+CLI-based agents operate in a black box — no visibility into running tasks, no way to monitor multiple bots, no real-time insight into what the agent is doing.
 
-**CachiBot gives you full visibility:**
-- Watch your bots work in real-time through the dashboard
-- See every task, job, and chat in a clean interface
-- Monitor connections to Telegram, Discord, and other platforms
-- Approve or reject actions before they execute
-- Full audit trail of everything your bots do
+**CachiBot gives you full visibility.** Watch your bots work through a dashboard, see every task and job in a clean interface, approve or reject actions before they execute, and maintain a full audit trail of everything your bots do.
 
 ## Features
 
 - **Visual Dashboard** — See all your bots, their status, and activity at a glance
-- **Real-time Monitoring** — Watch tasks and jobs execute with live updates
+- **Real-time Monitoring** — Watch tasks and jobs execute with live WebSocket updates
 - **Multi-Bot Management** — Create and manage multiple specialized bots
 - **Platform Connections** — Connect bots to Telegram, Discord, and more
 - **Knowledge Base** — Upload documents to give bots specialized knowledge
-- **Secure Sandbox** — Code runs in isolated environment with restricted imports
+- **Secure Sandbox** — Code runs in isolation with AST-based risk analysis
 - **Approval Flow** — Visual approval for risky operations before they execute
-- **Multi-Provider** — Kimi K2.5, Claude, OpenAI, and more
+- **Multi-Provider** — Kimi K2.5, Claude, OpenAI, Ollama, Groq, and more
 
 ## Quick Start
 
@@ -63,109 +75,69 @@ pip install cachibot
 ### 2. Set your API key
 
 ```bash
-# For Moonshot/Kimi (default)
-export MOONSHOT_API_KEY="your-api-key"
+# Moonshot/Kimi (default)
+export MOONSHOT_API_KEY="your-key"
 
-# Or for Claude
-export ANTHROPIC_API_KEY="your-api-key"
+# Or Claude
+export ANTHROPIC_API_KEY="your-key"
 
-# Or for OpenAI
-export OPENAI_API_KEY="your-api-key"
+# Or OpenAI
+export OPENAI_API_KEY="your-key"
 ```
 
-### 3. Run CachiBot
+### 3. Launch
 
 ```bash
 cachibot server
 ```
 
-Open **http://localhost:6392** in your browser. The frontend is bundled and served automatically.
+Open **http://localhost:6392** — the frontend is bundled and served automatically.
 
 ### CLI Usage
 
 ```bash
-# Start the dashboard server
-cachibot server
-
-# Run a single task
-cachibot "list all Python files"
-
-# Interactive mode
-cachibot
-
-# Use a specific model
-cachibot --model anthropic/claude-sonnet-4-20250514 "explain this code"
-
-# Short alias works too
-cachi server
+cachibot server                              # Start the dashboard
+cachibot "list all Python files"             # Run a single task
+cachibot                                     # Interactive mode
+cachibot --model anthropic/claude-sonnet-4-20250514 "explain this"  # Specific model
+cachi server                                 # Short alias
 ```
 
 ## Architecture
 
+```mermaid
+graph TB
+    subgraph Frontend["React Dashboard"]
+        Bots[Bots]
+        Chats[Chats]
+        Jobs[Jobs & Tasks]
+        KB[Knowledge Base]
+        Conn[Connections]
+    end
+
+    subgraph Backend["FastAPI Backend"]
+        Agent["Prompture Agent"]
+        Tools["Tool Registry"]
+        Sandbox["Sandbox Executor"]
+    end
+
+    subgraph Providers["LLM Providers"]
+        Moonshot[Moonshot/Kimi]
+        Claude[Claude]
+        OpenAI[OpenAI]
+        Ollama[Ollama]
+        Groq[Groq]
+    end
+
+    subgraph Platforms["Platform Connections"]
+        Telegram[Telegram]
+        Discord[Discord]
+    end
+
+    Frontend -- "WebSocket / REST" --> Backend
+    Backend --> Providers
+    Backend --> Platforms
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                         CachiBot                                 │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │                  React Dashboard                         │    │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────┐  │    │
-│  │  │   Bots   │  │  Chats   │  │   Jobs   │  │ Tasks  │  │    │
-│  │  └──────────┘  └──────────┘  └──────────┘  └────────┘  │    │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────────────────┐  │    │
-│  │  │ Settings │  │Knowledge │  │    Connections       │  │    │
-│  │  └──────────┘  └──────────┘  └──────────────────────┘  │    │
-│  └────────────────────────┬────────────────────────────────┘    │
-│                           │ WebSocket / REST                     │
-│  ┌────────────────────────▼────────────────────────────────┐    │
-│  │              FastAPI Backend                             │    │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────────────────┐   │    │
-│  │  │Prompture │  │  Tools   │  │   Sandbox Executor   │   │    │
-│  │  │  Agent   │  │ Registry │  │  (Isolated Python)   │   │    │
-│  │  └──────────┘  └──────────┘  └──────────────────────┘   │    │
-│  └────────────────────────┬────────────────────────────────┘    │
-│                           │                                      │
-│  ┌────────────────────────▼────────────────────────────────┐    │
-│  │             LLM Providers (via Prompture)                │    │
-│  │   Moonshot  │  Claude  │  OpenAI  │  Ollama  │  Groq    │    │
-│  └──────────────────────────────────────────────────────────┘    │
-│                           │                                      │
-│  ┌────────────────────────▼────────────────────────────────┐    │
-│  │              Platform Connections                        │    │
-│  │         Telegram  │  Discord  │  (more coming)          │    │
-│  └──────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## Security
-
-CachiBot is built with security as a core principle:
-
-### Visibility = Security
-
-The biggest security risk with AI agents is not knowing what they're doing. CachiBot solves this by making everything visible:
-
-- **See every action** before it executes
-- **Approve or reject** risky operations
-- **Full audit trail** of all bot activity
-- **Real-time monitoring** of running tasks
-
-### Sandboxed Execution
-
-Python code runs in a **sandboxed environment**:
-
-- **Import Restrictions** — Only safe modules allowed (json, math, datetime, etc.)
-- **Path Restrictions** — Can only access files in the workspace
-- **Execution Timeout** — Code killed after timeout (default: 30s)
-- **Risk Analysis** — AST-based detection of dangerous operations
-
-### Always Blocked
-
-These are never allowed regardless of configuration:
-- `subprocess`, `os.system`, `ctypes`
-- `socket`, `ssl`, raw network access
-- `importlib`, `eval`, `exec` (dynamic code)
-- `pickle`, `marshal` (unsafe serialization)
 
 ## Supported Models
 
@@ -174,41 +146,74 @@ These are never allowed regardless of configuration:
 | Moonshot | `moonshot/kimi-k2.5` | `MOONSHOT_API_KEY` |
 | Claude | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
 | OpenAI | `openai/gpt-4o` | `OPENAI_API_KEY` |
-| Ollama | `ollama/llama3.1:8b` | (local, no key) |
+| Ollama | `ollama/llama3.1:8b` | (local, no key needed) |
 | Groq | `groq/llama-3.1-70b` | `GROQ_API_KEY` |
+
+## Security
+
+CachiBot is built with security as a core principle. **Visibility is security** — the biggest risk with AI agents is not knowing what they're doing.
+
+### Sandboxed Execution
+
+Python code runs in a restricted environment:
+
+- **Import Restrictions** — Only safe modules allowed (json, math, datetime, etc.)
+- **Path Restrictions** — File access limited to the workspace
+- **Execution Timeout** — Code killed after timeout (default: 30s)
+- **Risk Analysis** — AST-based detection of dangerous operations
+
+### Always Blocked
+
+These are never allowed regardless of configuration: `subprocess`, `os.system`, `ctypes`, `socket`, `ssl`, `importlib`, `eval`, `exec`, `pickle`, `marshal`.
+
+## Roadmap
+
+- [x] Visual dashboard with real-time monitoring
+- [x] Multi-bot management
+- [x] Sandboxed Python execution
+- [x] Multi-provider LLM support
+- [x] Knowledge base with document upload
+- [x] Telegram integration
+- [x] Discord integration
+- [x] Plugin marketplace
+- [ ] Voice interface
+- [ ] Mobile companion app
 
 ## Contributing
 
 Contributions are welcome!
 
 ```bash
-# Clone the repo
 git clone https://github.com/jhd3197/CachiBot.git
 cd CachiBot
 
-# Install backend in development mode
+# Backend
 pip install -e ".[dev]"
-
-# Install frontend dependencies
-cd frontend && npm install
-
-# Start backend (dev)
 cachibot server --reload
 
-# Start frontend dev server (in another terminal)
-cd frontend && npm run dev
+# Frontend (in another terminal)
+cd frontend && npm install && npm run dev
 
-# Run tests
+# Tests & linting
 pytest
-
-# Lint
 ruff check src/
 cd frontend && npm run lint
 ```
 
+## Community
+
+<p align="center">
+  <a href="https://discord.gg/V9bKwYVJ">
+    <img src="https://img.shields.io/badge/Discord-Join_the_community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
+  </a>
+  <a href="https://github.com/jhd3197/CachiBot/issues">
+    <img src="https://img.shields.io/badge/Issues-Report_a_bug-red?style=for-the-badge&logo=github&logoColor=white" alt="Issues" />
+  </a>
+</p>
+
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT License — see [LICENSE](LICENSE) for details.
 
 ## Credits
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,228 @@
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/0855ecf4-c0ec-4d81-ad2a-3887d3688cb1" alt="CachiBot" width="800" />
+
+  <h1>CachiBot</h1>
+
+  <p><strong>El Agente de IA Blindado</strong></p>
+  <p><em>Visual. Transparente. Seguro.</em></p>
+
+  <p>
+    <a href="../README.md">English</a> ·
+    Español ·
+    <a href="README.zh-CN.md">中文版</a> ·
+    <a href="README.pt.md">Português</a>
+  </p>
+
+  <p>
+    <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
+    <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS" />
+    <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux" />
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/v/cachibot.svg" alt="PyPI" /></a>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/dm/cachibot.svg" alt="Descargas" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="Licencia" /></a>
+    <a href="https://python.org"><img src="https://img.shields.io/badge/Python-3.10+-blue.svg" alt="Python" /></a>
+    <a href="https://react.dev"><img src="https://img.shields.io/badge/React-18+-61DAFB.svg" alt="React" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/stargazers"><img src="https://img.shields.io/github/stars/jhd3197/CachiBot?style=social" alt="Estrellas" /></a>
+    <a href="https://discord.gg/V9bKwYVJ"><img src="https://img.shields.io/discord/1470624345188732992?label=Discord&logo=discord&logoColor=white&color=5865F2" alt="Discord" /></a>
+  </p>
+
+  <p>
+    Una plataforma de agentes de IA visual con transparencia total. Nombrado en honor al <em>cachicamo</em> venezolano (armadillo) — construido para ser blindado, auditable y bajo tu control.
+  </p>
+
+  <p>
+    <a href="#-inicio-rápido">Inicio Rápido</a> ·
+    <a href="#-características">Características</a> ·
+    <a href="#-arquitectura">Arquitectura</a> ·
+    <a href="#-seguridad">Seguridad</a> ·
+    <a href="#-contribuir">Contribuir</a> ·
+    <a href="https://discord.gg/V9bKwYVJ">Discord</a>
+  </p>
+
+</div>
+
+---
+
+## ¿Por qué Visual?
+
+La mayoría de los agentes de IA se ejecutan en terminales donde no puedes ver lo que está sucediendo. Eso es una pesadilla de seguridad.
+
+Los agentes basados en CLI operan en una caja negra — sin visibilidad de las tareas en ejecución, sin forma de monitorear múltiples bots, sin información en tiempo real de lo que el agente está haciendo.
+
+**CachiBot te da visibilidad completa.** Observa cómo trabajan tus bots a través de un tablero, ve cada tarea y trabajo en una interfaz limpia, aprueba o rechaza acciones antes de que se ejecuten, y mantén un registro de auditoría completo de todo lo que hacen tus bots.
+
+## Características
+
+- **Tablero Visual** — Ve todos tus bots, su estado y actividad de un vistazo
+- **Monitoreo en Tiempo Real** — Observa la ejecución de tareas y trabajos con actualizaciones en vivo por WebSocket
+- **Gestión Multi-Bot** — Crea y gestiona múltiples bots especializados
+- **Conexiones de Plataforma** — Conecta bots a Telegram, Discord y más
+- **Base de Conocimiento** — Sube documentos para dar conocimiento especializado a los bots
+- **Sandbox Seguro** — El código se ejecuta aislado con análisis de riesgo basado en AST
+- **Flujo de Aprobación** — Aprobación visual para operaciones riesgosas antes de ejecutarse
+- **Multi-Proveedor** — Kimi K2.5, Claude, OpenAI, Ollama, Groq y más
+
+## Inicio Rápido
+
+### 1. Instalar
+
+```bash
+pip install cachibot
+```
+
+### 2. Configura tu clave API
+
+```bash
+# Moonshot/Kimi (predeterminado)
+export MOONSHOT_API_KEY="tu-clave"
+
+# O Claude
+export ANTHROPIC_API_KEY="tu-clave"
+
+# O OpenAI
+export OPENAI_API_KEY="tu-clave"
+```
+
+### 3. Lanzar
+
+```bash
+cachibot server
+```
+
+Abre **http://localhost:6392** — el frontend viene empaquetado y se sirve automáticamente.
+
+### Uso de CLI
+
+```bash
+cachibot server                              # Inicia el tablero
+cachibot "listar todos los archivos Python"  # Ejecuta una tarea única
+cachibot                                     # Modo interactivo
+cachibot --model anthropic/claude-sonnet-4-20250514 "explica esto"  # Modelo específico
+cachi server                                 # Alias corto
+```
+
+## Arquitectura
+
+```mermaid
+graph TB
+    subgraph Frontend["React Dashboard"]
+        Bots[Bots]
+        Chats[Chats]
+        Jobs[Jobs & Tasks]
+        KB[Knowledge Base]
+        Conn[Connections]
+    end
+
+    subgraph Backend["FastAPI Backend"]
+        Agent["Prompture Agent"]
+        Tools["Tool Registry"]
+        Sandbox["Sandbox Executor"]
+    end
+
+    subgraph Providers["LLM Providers"]
+        Moonshot[Moonshot/Kimi]
+        Claude[Claude]
+        OpenAI[OpenAI]
+        Ollama[Ollama]
+        Groq[Groq]
+    end
+
+    subgraph Platforms["Platform Connections"]
+        Telegram[Telegram]
+        Discord[Discord]
+    end
+
+    Frontend -- "WebSocket / REST" --> Backend
+    Backend --> Providers
+    Backend --> Platforms
+```
+
+## Modelos Soportados
+
+| Proveedor | Modelo | Variable de Entorno |
+|----------|-------|---------------------|
+| Moonshot | `moonshot/kimi-k2.5` | `MOONSHOT_API_KEY` |
+| Claude | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| OpenAI | `openai/gpt-4o` | `OPENAI_API_KEY` |
+| Ollama | `ollama/llama3.1:8b` | (local, sin clave necesaria) |
+| Groq | `groq/llama-3.1-70b` | `GROQ_API_KEY` |
+
+## Seguridad
+
+CachiBot está construido con la seguridad como principio fundamental. **La visibilidad es seguridad** — el mayor riesgo con los agentes de IA es no saber qué están haciendo.
+
+### Ejecución en Sandbox
+
+El código Python se ejecuta en un entorno restringido:
+
+- **Restricciones de Importación** — Solo se permiten módulos seguros (json, math, datetime, etc.)
+- **Restricciones de Ruta** — Acceso a archivos limitado al espacio de trabajo
+- **Tiempo de Ejecución Límite** — El código se detiene después del tiempo límite (predeterminado: 30s)
+- **Análisis de Riesgo** — Detección basada en AST de operaciones peligrosas
+
+### Siempre Bloqueado
+
+Estos nunca se permiten independientemente de la configuración: `subprocess`, `os.system`, `ctypes`, `socket`, `ssl`, `importlib`, `eval`, `exec`, `pickle`, `marshal`.
+
+## Hoja de Ruta
+
+- [x] Tablero visual con monitoreo en tiempo real
+- [x] Gestión multi-bot
+- [x] Ejecución de Python en sandbox
+- [x] Soporte multi-proveedor de LLM
+- [x] Base de conocimiento con carga de documentos
+- [x] Integración con Telegram
+- [x] Integración con Discord
+- [ ] Mercado de plugins
+- [ ] Interfaz de voz
+- [ ] Aplicación móvil complementaria
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas!
+
+```bash
+git clone https://github.com/jhd3197/CachiBot.git
+cd CachiBot
+
+# Backend
+pip install -e ".[dev]"
+cachibot server --reload
+
+# Frontend (en otra terminal)
+cd frontend && npm install && npm run dev
+
+# Pruebas y linting
+pytest
+ruff check src/
+cd frontend && npm run lint
+```
+
+## Comunidad
+
+<p align="center">
+  <a href="https://discord.gg/V9bKwYVJ">
+    <img src="https://img.shields.io/badge/Discord-Únete_a_la_comunidad-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
+  </a>
+  <a href="https://github.com/jhd3197/CachiBot/issues">
+    <img src="https://img.shields.io/badge/Issues-Reporta_un_error-red?style=for-the-badge&logo=github&logoColor=white" alt="Issues" />
+  </a>
+</p>
+
+## Licencia
+
+Licencia MIT — ver [LICENSE](LICENSE) para más detalles.
+
+## Créditos
+
+- Construido con [Prompture](https://github.com/jhd3197/Prompture) para interacción estructurada con LLM
+- Nombrado en honor al *cachicamo* venezolano (armadillo)
+
+---
+
+<p align="center">
+  Hecho con cariño por <a href="https://juandenis.com">Juan Denis</a>
+</p>

--- a/docs/README.pt.md
+++ b/docs/README.pt.md
@@ -1,0 +1,228 @@
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/0855ecf4-c0ec-4d81-ad2a-3887d3688cb1" alt="CachiBot" width="800" />
+
+  <h1>CachiBot</h1>
+
+  <p><strong>O Agente de IA Blindado</strong></p>
+  <p><em>Visual. Transparente. Seguro.</em></p>
+
+  <p>
+    <a href="../README.md">English</a> ·
+    <a href="README.es.md">Español</a> ·
+    <a href="README.zh-CN.md">中文版</a> ·
+    Português
+  </p>
+
+  <p>
+    <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
+    <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS" />
+    <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux" />
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/v/cachibot.svg" alt="PyPI" /></a>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/dm/cachibot.svg" alt="Downloads" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License" /></a>
+    <a href="https://python.org"><img src="https://img.shields.io/badge/Python-3.10+-blue.svg" alt="Python" /></a>
+    <a href="https://react.dev"><img src="https://img.shields.io/badge/React-18+-61DAFB.svg" alt="React" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/stargazers"><img src="https://img.shields.io/github/stars/jhd3197/CachiBot?style=social" alt="Stars" /></a>
+    <a href="https://discord.gg/V9bKwYVJ"><img src="https://img.shields.io/discord/1470624345188732992?label=Discord&logo=discord&logoColor=white&color=5865F2" alt="Discord" /></a>
+  </p>
+
+  <p>
+    Uma plataforma de agentes de IA visual com total transparência. Nomeado em homenagem ao <em>cachicamo</em> venezuelano (tatu) — construído para ser blindado, auditável e seu para controlar.
+  </p>
+
+  <p>
+    <a href="#-início-rápido">Início Rápido</a> ·
+    <a href="#-recursos">Recursos</a> ·
+    <a href="#-arquitetura">Arquitetura</a> ·
+    <a href="#-segurança">Segurança</a> ·
+    <a href="#-contribuindo">Contribuindo</a> ·
+    <a href="https://discord.gg/V9bKwYVJ">Discord</a>
+  </p>
+
+</div>
+
+---
+
+## Por que Visual?
+
+A maioria dos agentes de IA roda em terminais onde você não consegue ver o que está acontecendo. Isso é um pesadelo de segurança.
+
+Agentes baseados em CLI operam numa caixa preta — sem visibilidade das tarefas em execução, sem forma de monitorar múltiplos bots, sem insight em tempo real sobre o que o agente está fazendo.
+
+**CachiBot te dá visibilidade total.** Observe seus bots trabalhando através de um painel, veja cada tarefa e job numa interface limpa, aprove ou rejeite ações antes que elas sejam executadas, e mantenha um registro completo de auditoria de tudo que seus bots fazem.
+
+## Recursos
+
+- **Painel Visual** — Veja todos os seus bots, seu status e atividade de relance
+- **Monitoramento em Tempo Real** — Observe tarefas e jobs executarem com atualizações WebSocket ao vivo
+- **Gerenciamento Multi-Bot** — Crie e gerencie múltiplos bots especializados
+- **Conexões de Plataforma** — Conecte bots ao Telegram, Discord e mais
+- **Base de Conhecimento** — Faça upload de documentos para dar conhecimento especializado aos bots
+- **Sandbox Seguro** — Código roda em isolamento com análise de risco baseada em AST
+- **Fluxo de Aprovação** — Aprovação visual para operações arriscadas antes da execução
+- **Multi-Provedor** — Kimi K2.5, Claude, OpenAI, Ollama, Groq e mais
+
+## Início Rápido
+
+### 1. Instalar
+
+```bash
+pip install cachibot
+```
+
+### 2. Definir sua chave de API
+
+```bash
+# Moonshot/Kimi (padrão)
+export MOONSHOT_API_KEY="sua-chave"
+
+# Ou Claude
+export ANTHROPIC_API_KEY="sua-chave"
+
+# Ou OpenAI
+export OPENAI_API_KEY="sua-chave"
+```
+
+### 3. Iniciar
+
+```bash
+cachibot server
+```
+
+Abra **http://localhost:6392** — o frontend é empacotado e servido automaticamente.
+
+### Uso via CLI
+
+```bash
+cachibot server                              # Inicia o painel
+cachibot "listar todos os arquivos Python"   # Executa uma única tarefa
+cachibot                                     # Modo interativo
+cachibot --model anthropic/claude-sonnet-4-20250514 "explique isso"  # Modelo específico
+cachi server                                 # Alias curto
+```
+
+## Arquitetura
+
+```mermaid
+graph TB
+    subgraph Frontend["React Dashboard"]
+        Bots[Bots]
+        Chats[Chats]
+        Jobs[Jobs & Tasks]
+        KB[Knowledge Base]
+        Conn[Connections]
+    end
+
+    subgraph Backend["FastAPI Backend"]
+        Agent["Prompture Agent"]
+        Tools["Tool Registry"]
+        Sandbox["Sandbox Executor"]
+    end
+
+    subgraph Providers["LLM Providers"]
+        Moonshot[Moonshot/Kimi]
+        Claude[Claude]
+        OpenAI[OpenAI]
+        Ollama[Ollama]
+        Groq[Groq]
+    end
+
+    subgraph Platforms["Platform Connections"]
+        Telegram[Telegram]
+        Discord[Discord]
+    end
+
+    Frontend -- "WebSocket / REST" --> Backend
+    Backend --> Providers
+    Backend --> Platforms
+```
+
+## Modelos Suportados
+
+| Provedor | Modelo | Variável de Ambiente |
+|----------|--------|---------------------|
+| Moonshot | `moonshot/kimi-k2.5` | `MOONSHOT_API_KEY` |
+| Claude | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| OpenAI | `openai/gpt-4o` | `OPENAI_API_KEY` |
+| Ollama | `ollama/llama3.1:8b` | (local, não precisa de chave) |
+| Groq | `groq/llama-3.1-70b` | `GROQ_API_KEY` |
+
+## Segurança
+
+CachiBot é construído com segurança como princípio fundamental. **Visibilidade é segurança** — o maior risco com agentes de IA é não saber o que eles estão fazendo.
+
+### Execução em Sandbox
+
+Código Python roda num ambiente restrito:
+
+- **Restrições de Importação** — Apenas módulos seguros permitidos (json, math, datetime, etc.)
+- **Restrições de Caminho** — Acesso a arquivos limitado ao workspace
+- **Timeout de Execução** — Código encerrado após timeout (padrão: 30s)
+- **Análise de Risco** — Detecção baseada em AST de operações perigosas
+
+### Sempre Bloqueado
+
+Estes nunca são permitidos independentemente da configuração: `subprocess`, `os.system`, `ctypes`, `socket`, `ssl`, `importlib`, `eval`, `exec`, `pickle`, `marshal`.
+
+## Roteiro
+
+- [x] Painel visual com monitoramento em tempo real
+- [x] Gerenciamento multi-bot
+- [x] Execução Python em sandbox
+- [x] Suporte multi-provedor de LLM
+- [x] Base de conhecimento com upload de documentos
+- [x] Integração com Telegram
+- [x] Integração com Discord
+- [ ] Marketplace de plugins
+- [ ] Interface de voz
+- [ ] App mobile complementar
+
+## Contribuindo
+
+Contribuições são bem-vindas!
+
+```bash
+git clone https://github.com/jhd3197/CachiBot.git
+cd CachiBot
+
+# Backend
+pip install -e ".[dev]"
+cachibot server --reload
+
+# Frontend (em outro terminal)
+cd frontend && npm install && npm run dev
+
+# Testes e linting
+pytest
+ruff check src/
+cd frontend && npm run lint
+```
+
+## Comunidade
+
+<p align="center">
+  <a href="https://discord.gg/V9bKwYVJ">
+    <img src="https://img.shields.io/badge/Discord-Junte_se_à_comunidade-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
+  </a>
+  <a href="https://github.com/jhd3197/CachiBot/issues">
+    <img src="https://img.shields.io/badge/Issues-Reporte_um_bug-red?style=for-the-badge&logo=github&logoColor=white" alt="Issues" />
+  </a>
+</p>
+
+## Licença
+
+Licença MIT — veja [LICENSE](LICENSE) para detalhes.
+
+## Créditos
+
+- Construído com [Prompture](https://github.com/jhd3197/Prompture) para interação estruturada com LLM
+- Nomeado em homenagem ao *cachicamo* venezuelano (tatu)
+
+---
+
+<p align="center">
+  Feito com carinho por <a href="https://juandenis.com">Juan Denis</a>
+</p>

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,228 @@
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/0855ecf4-c0ec-4d81-ad2a-3887d3688cb1" alt="CachiBot" width="800" />
+
+  <h1>CachiBot</h1>
+
+  <p><strong>铠甲 AI 智能体</strong></p>
+  <p><em>可视化。透明。安全。</em></p>
+
+  <p>
+    <a href="../README.md">English</a> ·
+    <a href="README.es.md">Español</a> ·
+    中文版 ·
+    <a href="README.pt.md">Português</a>
+  </p>
+
+  <p>
+    <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
+    <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS" />
+    <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux" />
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/v/cachibot.svg" alt="PyPI" /></a>
+    <a href="https://pypi.org/project/cachibot"><img src="https://img.shields.io/pypi/dm/cachibot.svg" alt="下载量" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="许可证" /></a>
+    <a href="https://python.org"><img src="https://img.shields.io/badge/Python-3.10+-blue.svg" alt="Python" /></a>
+    <a href="https://react.dev"><img src="https://img.shields.io/badge/React-18+-61DAFB.svg" alt="React" /></a>
+    <a href="https://github.com/jhd3197/CachiBot/stargazers"><img src="https://img.shields.io/github/stars/jhd3197/CachiBot?style=social" alt="Stars" /></a>
+    <a href="https://discord.gg/V9bKwYVJ"><img src="https://img.shields.io/discord/1470624345188732992?label=Discord&logo=discord&logoColor=white&color=5865F2" alt="Discord" /></a>
+  </p>
+
+  <p>
+    一个完全透明的可视化 AI 智能体平台。以委内瑞拉的犰狳（西班牙语：<em>cachicamo</em>）命名——如铠甲般安全、可审计、完全由你掌控。
+  </p>
+
+  <p>
+    <a href="#-快速开始">快速开始</a> ·
+    <a href="#-功能特性">功能特性</a> ·
+    <a href="#-架构">架构</a> ·
+    <a href="#-安全性">安全性</a> ·
+    <a href="#-贡献">贡献</a> ·
+    <a href="https://discord.gg/V9bKwYVJ">Discord</a>
+  </p>
+
+</div>
+
+---
+
+## 为什么需要可视化？
+
+大多数 AI 智能体在终端中运行，你无法看到正在发生什么。这是一个安全噩梦。
+
+基于命令行的智能体在黑盒中运行——无法看到正在运行的任务、无法监控多个机器人、无法实时了解智能体正在做什么。
+
+**CachiBot 为你提供完全的可见性。** 通过仪表板观察你的机器人工作，在简洁的界面中查看每个任务和作业，在操作执行前批准或拒绝，并维护机器人所做一切的完整审计追踪。
+
+## 功能特性
+
+- **可视化仪表板** — 一目了然地查看所有机器人的状态和活动
+- **实时监控** — 通过 WebSocket 实时更新观察任务和作业执行
+- **多机器人管理** — 创建和管理多个专用机器人
+- **平台连接** — 将机器人连接到 Telegram、Discord 等平台
+- **知识库** — 上传文档为机器人提供专业知识
+- **安全沙箱** — 代码在隔离环境中运行，具备基于 AST 的风险分析
+- **审批流程** — 危险操作执行前的可视化审批
+- **多模型提供商** — 支持 Kimi K2.5、Claude、OpenAI、Ollama、Groq 等
+
+## 快速开始
+
+### 1. 安装
+
+```bash
+pip install cachibot
+```
+
+### 2. 设置你的 API 密钥
+
+```bash
+# Moonshot/Kimi（默认）
+export MOONSHOT_API_KEY="your-key"
+
+# 或者 Claude
+export ANTHROPIC_API_KEY="your-key"
+
+# 或者 OpenAI
+export OPENAI_API_KEY="your-key"
+```
+
+### 3. 启动
+
+```bash
+cachibot server
+```
+
+打开 **http://localhost:6392** — 前端已打包并自动提供服务。
+
+### 命令行用法
+
+```bash
+cachibot server                              # 启动仪表板
+cachibot "list all Python files"             # 运行单个任务
+cachibot                                     # 交互模式
+cachibot --model anthropic/claude-sonnet-4-20250514 "explain this"  # 指定模型
+cachi server                                 # 短别名
+```
+
+## 架构
+
+```mermaid
+graph TB
+    subgraph Frontend["React Dashboard"]
+        Bots[Bots]
+        Chats[Chats]
+        Jobs[Jobs & Tasks]
+        KB[Knowledge Base]
+        Conn[Connections]
+    end
+
+    subgraph Backend["FastAPI Backend"]
+        Agent["Prompture Agent"]
+        Tools["Tool Registry"]
+        Sandbox["Sandbox Executor"]
+    end
+
+    subgraph Providers["LLM Providers"]
+        Moonshot[Moonshot/Kimi]
+        Claude[Claude]
+        OpenAI[OpenAI]
+        Ollama[Ollama]
+        Groq[Groq]
+    end
+
+    subgraph Platforms["Platform Connections"]
+        Telegram[Telegram]
+        Discord[Discord]
+    end
+
+    Frontend -- "WebSocket / REST" --> Backend
+    Backend --> Providers
+    Backend --> Platforms
+```
+
+## 支持的模型
+
+| 提供商 | 模型 | 环境变量 |
+|----------|-------|---------------------|
+| Moonshot | `moonshot/kimi-k2.5` | `MOONSHOT_API_KEY` |
+| Claude | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| OpenAI | `openai/gpt-4o` | `OPENAI_API_KEY` |
+| Ollama | `ollama/llama3.1:8b` | （本地运行，无需密钥） |
+| Groq | `groq/llama-3.1-70b` | `GROQ_API_KEY` |
+
+## 安全性
+
+CachiBot 以安全性为核心原则构建。**可见性即是安全性** — AI 智能体最大的风险是不知道它们在做什么。
+
+### 沙箱执行
+
+Python 代码在受限环境中运行：
+
+- **导入限制** — 仅允许安全模块（json、math、datetime 等）
+- **路径限制** — 文件访问仅限于工作空间
+- **执行超时** — 超时后终止代码（默认：30 秒）
+- **风险分析** — 基于 AST 的危险操作检测
+
+### 始终被阻止
+
+无论配置如何，这些操作始终不被允许：`subprocess`、`os.system`、`ctypes`、`socket`、`ssl`、`importlib`、`eval`、`exec`、`pickle`、`marshal`。
+
+## 路线图
+
+- [x] 具有实时监控的可视化仪表板
+- [x] 多机器人管理
+- [x] 沙箱化 Python 执行
+- [x] 多提供商 LLM 支持
+- [x] 带文档上传的知识库
+- [x] Telegram 集成
+- [x] Discord 集成
+- [ ] 插件市场
+- [ ] 语音界面
+- [ ] 移动伴侣应用
+
+## 贡献
+
+欢迎贡献！
+
+```bash
+git clone https://github.com/jhd3197/CachiBot.git
+cd CachiBot
+
+# 后端
+pip install -e ".[dev]"
+cachibot server --reload
+
+# 前端（在另一个终端）
+cd frontend && npm install && npm run dev
+
+# 测试和代码检查
+pytest
+ruff check src/
+cd frontend && npm run lint
+```
+
+## 社区
+
+<p align="center">
+  <a href="https://discord.gg/V9bKwYVJ">
+    <img src="https://img.shields.io/badge/Discord-Join_the_community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" />
+  </a>
+  <a href="https://github.com/jhd3197/CachiBot/issues">
+    <img src="https://img.shields.io/badge/Issues-Report_a_bug-red?style=for-the-badge&logo=github&logoColor=white" alt="Issues" />
+  </a>
+</p>
+
+## 许可证
+
+MIT 许可证 — 详见 [LICENSE](LICENSE)。
+
+## 致谢
+
+- 使用 [Prompture](https://github.com/jhd3197/Prompture) 构建，用于结构化的 LLM 交互
+- 以委内瑞拉的犰狳（西班牙语：*cachicamo*）命名
+
+---
+
+<p align="center">
+  用心打造 by <a href="https://juandenis.com">Juan Denis</a>
+</p>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -450,6 +450,41 @@ export async function previewBot(data: PreviewBotRequest): Promise<PreviewBotRes
   })
 }
 
+// Creation context analysis
+export interface SuggestedTodo {
+  title: string
+  notes: string
+}
+
+export interface SuggestedSchedule {
+  name: string
+  description: string
+  frequency: string
+}
+
+export interface AnalyzeContextRequest {
+  purpose_category: string
+  purpose_description: string
+  follow_up_answers: FollowUpAnswer[]
+  system_prompt: string
+  bot_name: string
+}
+
+export interface AnalyzeContextResponse {
+  user_context: string
+  suggested_todos: SuggestedTodo[]
+  suggested_schedules: SuggestedSchedule[]
+}
+
+export async function analyzeCreationContext(
+  data: AnalyzeContextRequest
+): Promise<AnalyzeContextResponse> {
+  return request('/creation/analyze-context', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
 // Bot sync (for platform connections)
 export interface BotSyncData {
   id: string

--- a/frontend/src/components/dialogs/CreateBotWizard/steps/SetupStep.tsx
+++ b/frontend/src/components/dialogs/CreateBotWizard/steps/SetupStep.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useRef } from 'react'
+import {
+  Loader2,
+  Sparkles,
+  UserCircle,
+  ListChecks,
+  CalendarClock,
+  Check,
+} from 'lucide-react'
+import { useCreationStore } from '../../../../stores/creation'
+import type { SuggestedTodoItem, SuggestedScheduleItem } from '../../../../stores/creation'
+import { analyzeCreationContext } from '../../../../api/client'
+
+export function SetupStep() {
+  const {
+    form,
+    isGenerating,
+    setGenerating,
+    setGenerationError,
+    updateForm,
+  } = useCreationStore()
+
+  const loadInitiatedRef = useRef(false)
+
+  useEffect(() => {
+    // Only run analysis once, when entering the step with no existing data
+    if (!loadInitiatedRef.current && !form.userContext && !isGenerating) {
+      loadInitiatedRef.current = true
+      runAnalysis()
+    }
+  }, [])
+
+  const runAnalysis = async () => {
+    setGenerating(true)
+    setGenerationError(null)
+
+    try {
+      const result = await analyzeCreationContext({
+        purpose_category: form.purposeCategory,
+        purpose_description: form.purposeDescription,
+        follow_up_answers: form.followUpQuestions
+          .filter((q) => q.answer.trim())
+          .map((q) => ({ question: q.question, answer: q.answer })),
+        system_prompt: form.systemPrompt,
+        bot_name: form.name,
+      })
+
+      updateForm({
+        userContext: result.user_context,
+        suggestedTodos: result.suggested_todos.map((t) => ({
+          ...t,
+          enabled: true,
+        })),
+        suggestedSchedules: result.suggested_schedules.map((s) => ({
+          ...s,
+          enabled: true,
+        })),
+      })
+    } catch (error) {
+      setGenerationError(
+        error instanceof Error ? error.message : 'Failed to analyze context'
+      )
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const toggleTodo = (index: number) => {
+    const updated = form.suggestedTodos.map((t: SuggestedTodoItem, i: number) =>
+      i === index ? { ...t, enabled: !t.enabled } : t
+    )
+    updateForm({ suggestedTodos: updated })
+  }
+
+  const toggleSchedule = (index: number) => {
+    const updated = form.suggestedSchedules.map((s: SuggestedScheduleItem, i: number) =>
+      i === index ? { ...s, enabled: !s.enabled } : s
+    )
+    updateForm({ suggestedSchedules: updated })
+  }
+
+  // Loading state
+  if (isGenerating) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-4">
+        <div className="relative">
+          <div className="absolute inset-0 animate-ping rounded-full bg-cachi-500/20" />
+          <div className="relative flex h-16 w-16 items-center justify-center rounded-full bg-cachi-500/10">
+            <Sparkles className="h-8 w-8 text-cachi-400" />
+          </div>
+        </div>
+        <div className="text-center">
+          <p className="text-lg font-medium text-zinc-200">
+            Analyzing your answers...
+          </p>
+          <p className="mt-1 text-sm text-zinc-500">
+            Extracting what {form.name} should know about you
+          </p>
+        </div>
+        <Loader2 className="h-5 w-5 animate-spin text-cachi-400" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* User Context Section */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-zinc-200">
+          <UserCircle className="h-4 w-4 text-cachi-400" />
+          What {form.name} knows about you
+        </div>
+        <textarea
+          value={form.userContext}
+          onChange={(e) => updateForm({ userContext: e.target.value })}
+          rows={5}
+          placeholder="Information about you that the bot should always remember..."
+          className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3 text-sm text-zinc-100 placeholder-zinc-600 outline-none transition-colors focus:border-cachi-500"
+        />
+        <p className="text-xs text-zinc-600">
+          This will be saved as Custom Instructions — your bot will always have
+          this context.
+        </p>
+      </div>
+
+      {/* Suggested Todos */}
+      {form.suggestedTodos.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-zinc-200">
+            <ListChecks className="h-4 w-4 text-cachi-400" />
+            Suggested todos
+          </div>
+          <div className="space-y-2">
+            {form.suggestedTodos.map((todo: SuggestedTodoItem, index: number) => (
+              <button
+                key={index}
+                type="button"
+                onClick={() => toggleTodo(index)}
+                className="flex w-full items-start gap-3 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3 text-left transition-colors hover:border-zinc-600"
+              >
+                <div
+                  className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
+                    todo.enabled
+                      ? 'border-cachi-500 bg-cachi-500 text-white'
+                      : 'border-zinc-600 bg-zinc-800'
+                  }`}
+                >
+                  {todo.enabled && <Check className="h-3 w-3" />}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p
+                    className={`text-sm font-medium ${
+                      todo.enabled ? 'text-zinc-200' : 'text-zinc-500 line-through'
+                    }`}
+                  >
+                    {todo.title}
+                  </p>
+                  {todo.notes && (
+                    <p className="mt-0.5 text-xs text-zinc-500">{todo.notes}</p>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-zinc-600">
+            Checked items will be created as todos for your bot.
+          </p>
+        </div>
+      )}
+
+      {/* Suggested Schedules */}
+      {form.suggestedSchedules.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-zinc-200">
+            <CalendarClock className="h-4 w-4 text-cachi-400" />
+            Suggested recurring tasks
+          </div>
+          <div className="space-y-2">
+            {form.suggestedSchedules.map(
+              (schedule: SuggestedScheduleItem, index: number) => (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => toggleSchedule(index)}
+                  className="flex w-full items-start gap-3 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3 text-left transition-colors hover:border-zinc-600"
+                >
+                  <div
+                    className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
+                      schedule.enabled
+                        ? 'border-cachi-500 bg-cachi-500 text-white'
+                        : 'border-zinc-600 bg-zinc-800'
+                    }`}
+                  >
+                    {schedule.enabled && <Check className="h-3 w-3" />}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={`text-sm font-medium ${
+                        schedule.enabled
+                          ? 'text-zinc-200'
+                          : 'text-zinc-500 line-through'
+                      }`}
+                    >
+                      {schedule.name}
+                    </p>
+                    <div className="mt-0.5 flex items-center gap-2 text-xs text-zinc-500">
+                      <span className="rounded bg-zinc-700/50 px-1.5 py-0.5">
+                        {schedule.frequency}
+                      </span>
+                      {schedule.description && (
+                        <span>{schedule.description}</span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              )
+            )}
+          </div>
+          <p className="text-xs text-zinc-600">
+            Checked items will be created as scheduled tasks.
+          </p>
+        </div>
+      )}
+
+      {/* Empty state if nothing was found */}
+      {!form.userContext &&
+        form.suggestedTodos.length === 0 &&
+        form.suggestedSchedules.length === 0 && (
+          <div className="rounded-lg border border-zinc-700/50 bg-zinc-800/30 p-6 text-center">
+            <p className="text-sm text-zinc-400">
+              No additional context was extracted. You can add custom
+              instructions manually after creating the bot.
+            </p>
+          </div>
+        )}
+    </div>
+  )
+}

--- a/frontend/src/components/views/SettingsView.tsx
+++ b/frontend/src/components/views/SettingsView.tsx
@@ -71,9 +71,10 @@ export function SettingsView() {
   }
 
   const handleDelete = () => {
-    deleteBot(activeBot.id)
+    const botId = activeBot.id
     setShowDeleteConfirm(false)
     navigate('/dashboard')
+    deleteBot(botId)
   }
 
   const sectionTitles = {
@@ -143,6 +144,7 @@ export function SettingsView() {
             <DangerSection
               botId={activeBot.id}
               botName={activeBot.name}
+              isDefault={activeBot.id === 'default'}
               onDelete={() => setShowDeleteConfirm(true)}
             />
           )}
@@ -814,10 +816,12 @@ function AdvancedSection() {
 function DangerSection({
   botId,
   botName,
+  isDefault,
   onDelete,
 }: {
   botId: string
   botName: string
+  isDefault: boolean
   onDelete: () => void
 }) {
   const [isExporting, setIsExporting] = useState(false)
@@ -870,20 +874,29 @@ function DangerSection({
       </div>
 
       {/* Delete section */}
-      <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-6">
-        <h3 className="text-lg font-semibold text-red-400">Delete this bot</h3>
-        <p className="mt-2 text-sm text-zinc-400">
-          Once you delete <strong className="text-zinc-200">{botName}</strong>, there is no going back.
-          All chats, jobs, and tasks will be permanently deleted.
-        </p>
-        <button
-          onClick={onDelete}
-          className="mt-4 flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
-        >
-          <Trash2 className="h-4 w-4" />
-          Delete Bot
-        </button>
-      </div>
+      {isDefault ? (
+        <div className="rounded-lg border border-zinc-700 bg-zinc-900/50 p-6">
+          <h3 className="text-lg font-semibold text-zinc-400">Delete this bot</h3>
+          <p className="mt-2 text-sm text-zinc-500">
+            The default bot cannot be deleted.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-6">
+          <h3 className="text-lg font-semibold text-red-400">Delete this bot</h3>
+          <p className="mt-2 text-sm text-zinc-400">
+            Once you delete <strong className="text-zinc-200">{botName}</strong>, there is no going back.
+            All chats, jobs, and tasks will be permanently deleted.
+          </p>
+          <button
+            onClick={onDelete}
+            className="mt-4 flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete Bot
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/stores/bots.ts
+++ b/frontend/src/stores/bots.ts
@@ -121,6 +121,9 @@ export const useBotStore = create<BotState>()(
       },
 
       deleteBot: (id) => {
+        // Prevent deletion of the default bot
+        if (id === 'default') return
+
         set((state) => ({
           bots: state.bots.filter((bot) => bot.id !== id),
           activeBotId: state.activeBotId === id ? state.bots[0]?.id ?? null : state.activeBotId,

--- a/frontend/src/stores/creation.ts
+++ b/frontend/src/stores/creation.ts
@@ -12,6 +12,7 @@ export type WizardStep =
   | 'details'
   | 'personality'
   | 'prompt-review'
+  | 'setup'
   | 'preview'
   | 'appearance'
   | 'confirm'
@@ -61,6 +62,20 @@ export interface FollowUpQuestion {
   answer: string
 }
 
+// Suggested items from creation analysis
+export interface SuggestedTodoItem {
+  title: string
+  notes: string
+  enabled: boolean
+}
+
+export interface SuggestedScheduleItem {
+  name: string
+  description: string
+  frequency: string
+  enabled: boolean
+}
+
 // Form data for bot creation
 export interface BotFormData {
   // Method selection
@@ -86,6 +101,11 @@ export interface BotFormData {
   suggestedName: string
   suggestedDescription: string
 
+  // Post-analysis setup
+  userContext: string
+  suggestedTodos: SuggestedTodoItem[]
+  suggestedSchedules: SuggestedScheduleItem[]
+
   // Final bot config
   name: string
   description: string
@@ -109,6 +129,9 @@ const defaultFormData: BotFormData = {
   generatedPrompt: '',
   suggestedName: '',
   suggestedDescription: '',
+  userContext: '',
+  suggestedTodos: [],
+  suggestedSchedules: [],
   name: '',
   description: '',
   icon: 'bot',
@@ -184,6 +207,7 @@ const STEP_FLOWS: Record<WizardMethod, WizardStep[]> = {
     'details',
     'personality',
     'prompt-review',
+    'setup',
     'preview',
     'appearance',
     'confirm',

--- a/src/cachibot/services/bot_creation_service.py
+++ b/src/cachibot/services/bot_creation_service.py
@@ -138,62 +138,62 @@ def _resolve_main_model() -> str:
         return "moonshot/kimi-k2.5"
 
 
-# Category-specific question templates as fallbacks
+# Category-specific question templates as fallbacks (user-centric)
 CATEGORY_QUESTIONS = {
     "fitness": [
-        FollowUpQuestion(id="q1", question="What are your main fitness goals?", placeholder="e.g., Lose weight, build muscle, improve endurance"),
-        FollowUpQuestion(id="q2", question="What equipment do you have access to?", placeholder="e.g., Full gym, dumbbells at home, no equipment"),
-        FollowUpQuestion(id="q3", question="Any injuries or limitations I should know about?", placeholder="e.g., Bad knees, lower back issues, none"),
+        FollowUpQuestion(id="q1", question="What's your name and what are your current fitness goals?", placeholder="e.g., I'm Maria, trying to lose 10kg and run a 5K by summer"),
+        FollowUpQuestion(id="q2", question="What does your typical week look like — when do you work out?", placeholder="e.g., I work 9-6, gym at 7am on weekdays, long run on Saturdays"),
+        FollowUpQuestion(id="q3", question="What tasks or reminders would help you stay on track?", placeholder="e.g., Remind me to stretch daily, track my calories, plan weekly workouts"),
     ],
     "cooking": [
-        FollowUpQuestion(id="q1", question="Any dietary restrictions or preferences?", placeholder="e.g., Vegetarian, gluten-free, keto, no restrictions"),
-        FollowUpQuestion(id="q2", question="What's your cooking skill level?", placeholder="e.g., Beginner, can follow recipes, experienced home cook"),
-        FollowUpQuestion(id="q3", question="How much time do you usually have to cook?", placeholder="e.g., 15 min quick meals, 30-45 min, I enjoy long cooking sessions"),
+        FollowUpQuestion(id="q1", question="What's your name and who do you usually cook for?", placeholder="e.g., I'm Sam, cooking for myself and my partner, they're vegetarian"),
+        FollowUpQuestion(id="q2", question="What does your weekly meal routine look like?", placeholder="e.g., Meal prep on Sundays, quick lunches during work, nice dinner on Fridays"),
+        FollowUpQuestion(id="q3", question="What cooking tasks would you want me to help with regularly?", placeholder="e.g., Weekly meal plans, grocery lists, new recipe ideas for date night"),
     ],
     "finance": [
-        FollowUpQuestion(id="q1", question="What's your main financial goal right now?", placeholder="e.g., Save for a house, pay off debt, build emergency fund"),
-        FollowUpQuestion(id="q2", question="How would you describe your spending habits?", placeholder="e.g., Impulsive buyer, careful planner, somewhere in between"),
-        FollowUpQuestion(id="q3", question="What areas of finance do you struggle with most?", placeholder="e.g., Budgeting, investing, tracking expenses"),
+        FollowUpQuestion(id="q1", question="What's your name and what's your current financial situation?", placeholder="e.g., I'm Jordan, just started a new job, trying to build an emergency fund"),
+        FollowUpQuestion(id="q2", question="What does your income and spending look like right now?", placeholder="e.g., Salary + freelance, biggest expenses are rent and eating out"),
+        FollowUpQuestion(id="q3", question="What financial tasks would you want me to remind you about?", placeholder="e.g., Track daily spending, review budget weekly, save $500/month"),
     ],
     "travel": [
-        FollowUpQuestion(id="q1", question="What type of traveler are you?", placeholder="e.g., Adventure seeker, relaxation, cultural explorer, budget backpacker"),
-        FollowUpQuestion(id="q2", question="Do you prefer solo travel, couples, or family trips?", placeholder="e.g., Solo, with partner, family with kids"),
-        FollowUpQuestion(id="q3", question="Any destinations or experiences on your bucket list?", placeholder="e.g., Japan, Northern Lights, road trip across Europe"),
+        FollowUpQuestion(id="q1", question="What's your name and what kind of trips do you enjoy?", placeholder="e.g., I'm Chris, love backpacking through Southeast Asia on a budget"),
+        FollowUpQuestion(id="q2", question="Any upcoming trips or travel goals you're working towards?", placeholder="e.g., Planning 2-week Japan trip in March, need to save for it"),
+        FollowUpQuestion(id="q3", question="What travel tasks would you want help with?", placeholder="e.g., Research destinations, create packing lists, track travel budget"),
     ],
     "coding": [
-        FollowUpQuestion(id="q1", question="What languages/technologies do you mainly work with?", placeholder="e.g., Python, React, full-stack web development"),
-        FollowUpQuestion(id="q2", question="What's your experience level?", placeholder="e.g., Beginner learning, mid-level professional, senior developer"),
-        FollowUpQuestion(id="q3", question="What kind of projects do you work on?", placeholder="e.g., Web apps, data science, mobile apps, DevOps"),
+        FollowUpQuestion(id="q1", question="What's your name and what do you do as a developer?", placeholder="e.g., I'm Alex, fullstack dev at a startup working with React + Python"),
+        FollowUpQuestion(id="q2", question="What are you currently working on or learning?", placeholder="e.g., Building a SaaS product, learning Rust on the side"),
+        FollowUpQuestion(id="q3", question="What coding tasks would you want help with regularly?", placeholder="e.g., Code review, debugging, learning new patterns, planning features"),
     ],
     "writing": [
-        FollowUpQuestion(id="q1", question="What type of writing do you do most?", placeholder="e.g., Blog posts, fiction, technical docs, marketing copy"),
-        FollowUpQuestion(id="q2", question="Who is your target audience?", placeholder="e.g., Tech professionals, general public, B2B clients"),
-        FollowUpQuestion(id="q3", question="What do you struggle with most in writing?", placeholder="e.g., Starting, editing, finding my voice, meeting deadlines"),
+        FollowUpQuestion(id="q1", question="What's your name and what kind of writing do you do?", placeholder="e.g., I'm Pat, writing a sci-fi novel and weekly blog posts"),
+        FollowUpQuestion(id="q2", question="What does your writing routine look like?", placeholder="e.g., Write 1 hour before work, aim for 1000 words/day"),
+        FollowUpQuestion(id="q3", question="What writing tasks would you want me to help with?", placeholder="e.g., Daily writing prompts, editing feedback, outline my next chapter"),
     ],
     "learning": [
-        FollowUpQuestion(id="q1", question="What subjects are you studying or want to learn?", placeholder="e.g., Math, languages, programming, history"),
-        FollowUpQuestion(id="q2", question="How do you learn best?", placeholder="e.g., Visual examples, practice problems, explanations, flashcards"),
-        FollowUpQuestion(id="q3", question="What's your goal with learning?", placeholder="e.g., Pass exams, career change, personal interest"),
+        FollowUpQuestion(id="q1", question="What's your name and what are you currently studying?", placeholder="e.g., I'm Taylor, studying for AWS certification while working full-time"),
+        FollowUpQuestion(id="q2", question="What's your study schedule and learning goals?", placeholder="e.g., 30 min before bed on weekdays, exam in 3 months"),
+        FollowUpQuestion(id="q3", question="What study tasks would you want me to help track?", placeholder="e.g., Quiz me daily, track progress through chapters, remind me to review"),
     ],
     "productivity": [
-        FollowUpQuestion(id="q1", question="What's your biggest productivity challenge?", placeholder="e.g., Procrastination, too many tasks, losing focus"),
-        FollowUpQuestion(id="q2", question="What tools or methods have you tried?", placeholder="e.g., Pomodoro, to-do apps, calendar blocking"),
-        FollowUpQuestion(id="q3", question="What does a productive day look like for you?", placeholder="e.g., Finishing top 3 tasks, no distractions, balanced work-life"),
+        FollowUpQuestion(id="q1", question="What's your name and what do you do day-to-day?", placeholder="e.g., I'm Morgan, freelance designer juggling 3 clients + personal projects"),
+        FollowUpQuestion(id="q2", question="What does your ideal productive day look like?", placeholder="e.g., Deep work 9-12, meetings after lunch, personal time after 5"),
+        FollowUpQuestion(id="q3", question="What tasks or habits would you want me to track for you?", placeholder="e.g., Daily top-3 priorities, weekly review, break reminders"),
     ],
     "creative": [
-        FollowUpQuestion(id="q1", question="What type of creative work do you do?", placeholder="e.g., Digital art, music production, writing, photography"),
-        FollowUpQuestion(id="q2", question="What part of the creative process do you need help with?", placeholder="e.g., Brainstorming ideas, feedback, learning techniques"),
-        FollowUpQuestion(id="q3", question="Any specific style or aesthetic you're drawn to?", placeholder="e.g., Minimalist, retro, dark/moody, colorful"),
+        FollowUpQuestion(id="q1", question="What's your name and what creative work do you do?", placeholder="e.g., I'm Jamie, digital artist doing commissions + personal art"),
+        FollowUpQuestion(id="q2", question="What does your creative routine look like?", placeholder="e.g., Draw after dinner, post on Instagram Tuesdays and Fridays"),
+        FollowUpQuestion(id="q3", question="What creative tasks would you want help managing?", placeholder="e.g., Track commissions, brainstorm ideas, schedule posts"),
     ],
     "gaming": [
-        FollowUpQuestion(id="q1", question="What games or genres do you play most?", placeholder="e.g., RPGs, FPS, strategy, indie games"),
-        FollowUpQuestion(id="q2", question="What platform do you play on?", placeholder="e.g., PC, PlayStation, Switch, mobile"),
-        FollowUpQuestion(id="q3", question="What kind of help do you usually need?", placeholder="e.g., Strategy guides, build optimization, finding new games"),
+        FollowUpQuestion(id="q1", question="What's your name and what games are you into right now?", placeholder="e.g., I'm Riley, playing Elden Ring and Baldur's Gate 3 on PC"),
+        FollowUpQuestion(id="q2", question="What's your gaming schedule like?", placeholder="e.g., 2-3 hours on weeknights, longer sessions on weekends"),
+        FollowUpQuestion(id="q3", question="What gaming-related things would you want help with?", placeholder="e.g., Build guides for my character, track achievements, find new games"),
     ],
     "social": [
-        FollowUpQuestion(id="q1", question="What's your main goal in social situations?", placeholder="e.g., Better conversations, dating advice, networking"),
-        FollowUpQuestion(id="q2", question="What do you find most challenging socially?", placeholder="e.g., Starting conversations, keeping them going, confidence"),
-        FollowUpQuestion(id="q3", question="Any specific situations you want help with?", placeholder="e.g., First dates, work events, making friends"),
+        FollowUpQuestion(id="q1", question="What's your name and what's your social life like right now?", placeholder="e.g., I'm Casey, moved to a new city and trying to meet people"),
+        FollowUpQuestion(id="q2", question="What social situations come up most for you?", placeholder="e.g., Work networking events, dating apps, making friends at hobbies"),
+        FollowUpQuestion(id="q3", question="What would you want me to help you with specifically?", placeholder="e.g., Practice conversations, plan social outings, follow up with contacts"),
     ],
 }
 
@@ -217,38 +217,48 @@ async def generate_follow_up_questions(
     if model is None:
         model = _resolve_utility_model()
 
-    prompt_text = f"""Generate 3 follow-up questions to better understand what the user wants from their AI assistant.
+    prompt_text = f"""Generate 3 follow-up questions to learn about the USER so the bot can truly know them.
 
 ## Context
 - Category: {category}
 - User's description: "{description}"
 
 ## Requirements for questions:
-1. Questions should dig deeper into their specific needs
-2. Each question should reveal something unique about their use case
-3. Questions should be personal and conversational, not generic
+1. Questions should learn about the USER's identity, routine, and specific needs — not about bot preferences
+2. Ask about their name, schedule, current situation, and concrete tasks they need help with
+3. Questions should be warm and personal, making the user feel heard
 4. Include helpful placeholder text showing example answers
-5. Questions should help create a more personalized bot
+5. The answers will be used to create custom instructions so the bot always remembers who the user is
 
-Generate exactly 3 questions that will help customize this bot perfectly for the user."""
+## Good question examples:
+- "What's your name and how should I address you?"
+- "Tell me about your typical day/week — what does your routine look like?"
+- "What specific tasks, reminders, or recurring things would you want me to help with?"
+
+## Bad question examples (avoid these):
+- "What equipment do you have?" (too generic/impersonal)
+- "What's your skill level?" (about preferences, not the user)
+- "How do you prefer information?" (about bot style, not user identity)
+
+Generate exactly 3 questions that will help the bot KNOW the user personally."""
 
     instruction = "Generate 3 follow-up questions with placeholders in JSON format:"
 
     fallback_questions = CATEGORY_QUESTIONS.get(category, [
         FollowUpQuestion(
             id="q1",
-            question="What specific tasks should I help you with?",
-            placeholder="e.g., Daily tasks, specific projects, ongoing support",
+            question="What's your name and how should I address you?",
+            placeholder="e.g., I'm Alex, call me Alex or just A",
         ),
         FollowUpQuestion(
             id="q2",
-            question="How do you prefer to receive information?",
-            placeholder="e.g., Step-by-step, quick summaries, detailed explanations",
+            question="Tell me about your typical day or week — what does your routine look like?",
+            placeholder="e.g., I work 9-5 remotely, gym in the morning, study at night",
         ),
         FollowUpQuestion(
             id="q3",
-            question="Anything specific about your situation I should know?",
-            placeholder="e.g., Time constraints, preferences, past experiences",
+            question="What specific tasks or reminders would you want me to help with?",
+            placeholder="e.g., Track my workouts, remind me to meal prep on Sundays, help plan my week",
         ),
     ])
 
@@ -525,4 +535,133 @@ User: {test_message}"""
         logger.warning("Preview generation failed, using fallback")
         return PreviewResponse(
             response="I'm ready to help! How can I assist you today?",
+        )
+
+
+# =============================================================================
+# POST-CREATION CONTEXT ANALYSIS
+# =============================================================================
+
+
+class SuggestedTodo(BaseModel):
+    """A todo item extracted from the creation context."""
+
+    title: str = Field(description="Short actionable title for the todo")
+    notes: str = Field(default="", description="Additional details or context")
+
+
+class SuggestedSchedule(BaseModel):
+    """A recurring task/schedule extracted from the creation context."""
+
+    name: str = Field(description="Name of the recurring task")
+    description: str = Field(default="", description="What this schedule does")
+    frequency: str = Field(description="How often, e.g. 'daily', 'weekly on Mondays', 'every morning'")
+
+
+class CreationAnalysis(BaseModel):
+    """Analysis result from the creation context."""
+
+    user_context: str = Field(
+        description="Markdown text summarizing what the bot should know about the user. "
+        "Include name, routine, preferences, goals — everything the bot needs to "
+        "address the user personally."
+    )
+    suggested_todos: list[SuggestedTodo] = Field(
+        default_factory=list,
+        description="Actionable tasks/todos detected from the user's answers",
+    )
+    suggested_schedules: list[SuggestedSchedule] = Field(
+        default_factory=list,
+        description="Recurring tasks or schedules detected from the user's answers",
+    )
+
+
+async def analyze_creation_context(
+    purpose_category: str,
+    purpose_description: str,
+    follow_up_answers: list[tuple[str, str]],
+    system_prompt: str,
+    bot_name: str,
+    model: str | None = None,
+) -> CreationAnalysis:
+    """
+    Analyze all wizard data to extract user context, todos, and schedules.
+
+    This runs after the system prompt is generated and extracts structured
+    data that helps the bot truly know its user.
+
+    Args:
+        purpose_category: The bot's purpose category
+        purpose_description: What the user wants the bot to do
+        follow_up_answers: List of (question, answer) pairs
+        system_prompt: The generated system prompt
+        bot_name: The bot's name
+        model: Model to use for analysis
+
+    Returns:
+        CreationAnalysis with user_context, suggested_todos, suggested_schedules
+    """
+    if model is None:
+        model = _resolve_utility_model()
+
+    # Format follow-up Q&A
+    qa_section = ""
+    if follow_up_answers:
+        qa_section = "\n## User's Answers\n"
+        for question, answer in follow_up_answers:
+            if answer.strip():
+                qa_section += f"- Q: {question}\n  A: {answer}\n"
+
+    prompt_text = f"""Analyze the following bot creation context to extract structured information about the user.
+
+## Bot Being Created
+- Name: {bot_name}
+- Category: {purpose_category}
+- Purpose: {purpose_description}
+
+## System Prompt
+{system_prompt}
+{qa_section}
+## Your Task
+
+Extract three things from the above context:
+
+### 1. User Context (Custom Instructions)
+Write a concise markdown summary of everything the bot should ALWAYS know about its user.
+Include: name (if mentioned), routine/schedule, goals, preferences, situation, constraints.
+Write it as instructions TO the bot, e.g. "The user's name is Alex. They work 9-5..."
+Only include information that was actually mentioned — don't invent details.
+If no personal info was shared, write a brief note like "No personal details shared yet."
+
+### 2. Suggested Todos
+Extract any specific one-time tasks or action items the user mentioned.
+Examples: "Set up a workout plan", "Create a weekly meal prep list", "Research X"
+Only include clear, actionable items — not vague wishes.
+Return an empty list if none were mentioned.
+
+### 3. Suggested Schedules
+Extract any recurring activities or habits the user mentioned wanting help with.
+Examples: "Daily workout reminder", "Weekly meal planning on Sundays"
+Include the frequency (daily, weekly, etc.) based on what the user said.
+Return an empty list if none were mentioned."""
+
+    instruction = (
+        "Analyze the context and extract user_context, suggested_todos, "
+        "and suggested_schedules in JSON format:"
+    )
+
+    try:
+        result = await _extract_with_retry(
+            CreationAnalysis,
+            prompt_text,
+            model,
+            instruction_template=instruction,
+        )
+        return result.model
+    except Exception:
+        logger.exception("Creation context analysis failed")
+        return CreationAnalysis(
+            user_context="No personal details extracted yet.",
+            suggested_todos=[],
+            suggested_schedules=[],
         )


### PR DESCRIPTION
Introduce a post-creation analysis flow to extract user context, suggested todos, and recurring schedules.

Changes include:
- Backend: add analyze_creation_context service and /creation/analyze-context route returning structured user_context, suggested_todos, and suggested_schedules.
- Frontend API: add analyzeCreationContext client call and types.
- UI: new SetupStep in the CreateBot wizard to show extracted custom instructions, todos, and schedules (with toggles) and a loading state.
- Wizard wiring: include the setup step in the flow and save analysis results to the creation store.
- Creation finalization: when creating a bot (ai-assisted), save custom instructions and fire-and-forget createTodo/createSchedule calls for enabled suggestions.
- Stores: add suggested todo/schedule types and fields to creation store; prevent deletion of the default bot in bots store and SettingsView (disable delete UI for default bot).
- Bot-creation prompts: refine follow-up question templates to be more user-centric and extract personal/routine info.
- Docs/Dockerfile: update CLI invocation to use "cachibot server".

This enables better personalization by turning wizard answers into persistent custom instructions and actionable tasks/schedules.