### PR TITLE
Use configurable default model across app

### DIFF
--- a/frontend/src/components/views/ChatView.tsx
+++ b/frontend/src/components/views/ChatView.tsx
@@ -24,6 +24,7 @@ import {
 import { useChatStore, useBotStore } from '../../stores/bots'
 import { useUIStore, accentColors } from '../../stores/ui'
 import { useCreationFlowStore } from '../../stores/creation-flow'
+import { useModelsStore } from '../../stores/models'
 import { BotIconRenderer } from '../common/BotIconRenderer'
 import { MarkdownRenderer } from '../common/MarkdownRenderer'
 import { cn } from '../../lib/utils'
@@ -432,7 +433,7 @@ export function ChatView({ onSendMessage, onCancel, isConnected: isConnectedProp
         description: data.purposeDescription || `A ${data.purposeCategory} assistant`,
         icon: pickRandomIcon(),
         color: pickRandomColor(),
-        model: 'moonshot/kimi-k2.5',
+        model: useModelsStore.getState().defaultModel,
         systemPrompt,
         tools: ['file_read', 'file_write', 'python_execute'],
         createdAt: new Date().toISOString(),
@@ -873,7 +874,7 @@ export function ChatView({ onSendMessage, onCancel, isConnected: isConnectedProp
             <h2 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
               {activeBot?.name || 'CachiBot'}
             </h2>
-            <p className="text-xs text-zinc-500">{activeBot?.model || 'moonshot/kimi-k2.5'}</p>
+            <p className="text-xs text-zinc-500">{activeBot?.model || useModelsStore.getState().defaultModel || 'No model set'}</p>
           </div>
         </div>
         <button

--- a/frontend/src/components/views/SettingsView.tsx
+++ b/frontend/src/components/views/SettingsView.tsx
@@ -141,13 +141,14 @@ export function SettingsView() {
               form={form}
               setForm={setForm}
               onReset={() => {
+                const appDefault = useModelsStore.getState().defaultModel
                 setForm({
                   name: DEFAULT_BOT_SETTINGS.name,
                   description: DEFAULT_BOT_SETTINGS.description,
                   icon: DEFAULT_BOT_SETTINGS.icon,
                   color: DEFAULT_BOT_SETTINGS.color,
-                  model: DEFAULT_BOT_SETTINGS.model,
-                  models: { default: DEFAULT_BOT_SETTINGS.model, image: '', audio: '', structured: '' },
+                  model: appDefault,
+                  models: { default: appDefault, image: '', audio: '', structured: '' },
                   systemPrompt: DEFAULT_BOT_SETTINGS.systemPrompt,
                 })
               }}

--- a/frontend/src/stores/bots.ts
+++ b/frontend/src/stores/bots.ts
@@ -46,7 +46,7 @@ export const DEFAULT_BOT_SETTINGS: Pick<Bot, 'name' | 'description' | 'icon' | '
   description: 'The Armored AI Agent - your general-purpose assistant',
   icon: 'shield' as const,
   color: '#22c55e',
-  model: 'moonshot/kimi-k2.5',
+  model: '',
   systemPrompt: `You are CachiBot, a helpful AI assistant created by Juan Almonte.
 
 ## About Your Name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "prompture>=1.0.19",
+    "prompture>=1.0.28",
     "tukuy>=0.0.22",
     "typer>=0.12.0",
     "rich>=13.0.0",

--- a/src/cachibot/data/marketplace_templates.py
+++ b/src/cachibot/data/marketplace_templates.py
@@ -43,7 +43,7 @@ MARKETPLACE_TEMPLATES: dict[TemplateCategory, list[TemplateDefinition]] = {
             "color": "#3b82f6",
             "category": "productivity",
             "tags": ["meetings", "notes", "summary", "action items"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Meeting Notes Assistant, \
 expert at capturing and organizing meeting content.
 
@@ -75,7 +75,7 @@ Be professional but approachable. Focus on clarity and actionability.""",
             "color": "#8b5cf6",
             "category": "productivity",
             "tags": ["email", "writing", "professional", "communication"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Professional Email Writer, \
 helping craft effective emails for any business situation.
 
@@ -112,7 +112,7 @@ Ask clarifying questions if the context or recipient relationship is unclear."""
             "color": "#22c55e",
             "category": "productivity",
             "tags": ["tasks", "planning", "organization", "productivity"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Task Management Assistant, \
 helping organize and prioritize work effectively.
 
@@ -148,7 +148,7 @@ Be supportive but practical. Help users make progress, not perfect plans.""",
             "color": "#3b82f6",
             "category": "productivity",
             "tags": ["files", "automation", "cleanup", "organization"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a File Organization Assistant, \
 helping keep workspaces tidy and efficient.
 
@@ -186,7 +186,7 @@ I'll help you find what you need, when you need it.""",
             "color": "#ef4444",
             "category": "coding",
             "tags": ["code review", "debugging", "best practices", "quality"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are an Expert Code Reviewer \
 with deep knowledge of software engineering best practices.
 
@@ -224,7 +224,7 @@ Ask for context about the codebase conventions if needed.""",
             "color": "#06b6d4",
             "category": "coding",
             "tags": ["documentation", "api docs", "readme", "technical writing"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Technical Documentation Writer, \
 creating clear and useful documentation.
 
@@ -263,7 +263,7 @@ Write documentation that you would want to read.""",
             "color": "#f59e0b",
             "category": "coding",
             "tags": ["debugging", "troubleshooting", "testing", "investigation"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Bug Hunter, \
 systematically debugging issues using the scientific method.
 
@@ -309,7 +309,7 @@ Stay curious and methodical. Every bug has a cause.""",
             "color": "#ec4899",
             "category": "creative",
             "tags": ["writing", "fiction", "storytelling", "creative"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Creative Story Writer, helping craft engaging narratives.
 
 ## Story Elements I Help With
@@ -346,7 +346,7 @@ I'm here to enhance your creativity, not override it. Let's tell your story.""",
             "color": "#f97316",
             "category": "creative",
             "tags": ["marketing", "copy", "headlines", "conversion"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Conversion-Focused Copywriter, \
 crafting words that drive action.
 
@@ -389,7 +389,7 @@ Always ask: What's the #1 action we want them to take?""",
             "color": "#a855f7",
             "category": "creative",
             "tags": ["brainstorming", "ideas", "creativity", "innovation"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Brainstorm Buddy, \
 helping generate and explore creative ideas.
 
@@ -429,7 +429,7 @@ I believe in your creative potential. Let's explore together!""",
             "color": "#06b6d4",
             "category": "data",
             "tags": ["sql", "database", "queries", "optimization"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are an SQL Expert, helping write and optimize database queries.
 
 ## Capabilities
@@ -466,7 +466,7 @@ I'll write queries that are both correct and efficient.""",
             "color": "#22c55e",
             "category": "data",
             "tags": ["visualization", "charts", "graphs", "data analysis"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Data Visualization Expert, \
 creating clear and insightful visual representations.
 
@@ -503,7 +503,7 @@ Ask about the story you want to tell with the data.""",
             "color": "#3b82f6",
             "category": "data",
             "tags": ["csv", "analysis", "statistics", "data cleaning"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a CSV Data Analyst, helping explore and understand data.
 
 ## Analysis Capabilities
@@ -542,7 +542,7 @@ I'll use Python/pandas to analyze your data and explain findings clearly.""",
             "color": "#ec4899",
             "category": "learning",
             "tags": ["language", "learning", "tutor", "practice"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Patient Language Tutor, \
 helping learners master new languages.
 
@@ -580,7 +580,7 @@ Tell me your target language and current level to get started!""",
             "color": "#8b5cf6",
             "category": "learning",
             "tags": ["education", "explanations", "learning", "understanding"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Concept Explainer, \
 making complex ideas accessible and memorable.
 
@@ -617,7 +617,7 @@ No topic is too complex to understand. Let's break it down together!""",
             "color": "#f59e0b",
             "category": "learning",
             "tags": ["quiz", "testing", "flashcards", "memorization"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Quiz Master, \
 helping test and reinforce learning through active recall.
 
@@ -661,7 +661,7 @@ What topic would you like to be quizzed on?""",
             "color": "#3b82f6",
             "category": "support",
             "tags": ["troubleshooting", "tech support", "help desk", "issues"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Tech Support Specialist, \
 helping users resolve technical issues.
 
@@ -701,7 +701,7 @@ I'm patient and here to help. No question is too basic!""",
             "color": "#f59e0b",
             "category": "research",
             "tags": ["research", "notes", "summary", "analysis"],
-            "model": "moonshot/kimi-k2.5",
+            "model": "",
             "system_prompt": """You are a Research Assistant, \
 helping organize and synthesize information.
 

--- a/src/cachibot/services/command_processor.py
+++ b/src/cachibot/services/command_processor.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any
 
+from cachibot.config import Config
 from cachibot.models.bot import Bot
 from cachibot.models.command import (
     BOT_TEMPLATES,
@@ -424,13 +425,17 @@ class CommandProcessor:
         try:
             # Create the bot
             now = datetime.utcnow()
+            try:
+                default_model = Config.load().agent.model
+            except Exception:
+                default_model = "moonshot/kimi-k2.5"
             bot = Bot(
                 id=str(uuid.uuid4()),
                 name=name,
                 description=description,
                 icon="bot",
                 color="#22c55e",
-                model="moonshot/kimi-k2.5",
+                model=default_model,
                 systemPrompt=template["system_prompt"],
                 capabilities={},
                 createdAt=now,


### PR DESCRIPTION
Replace hardcoded 'moonshot/kimi-k2.5' with a configurable default model and fallbacks. Frontend: read default model from useModelsStore in ChatView and SettingsView; reset now uses the app default. Stores: DEFAULT_BOT_SETTINGS.model cleared to defer to app default. Marketplace/templates: template model fields cleared (empty) so installs inherit app default; API route resolves template model or falls back to Config.load().agent.model (with 'moonshot/kimi-k2.5' fallback). Backend command processor: use Config.load().agent.model (with fallback) when creating bots. This centralizes model configuration and avoids embedding a specific model string in multiple places.