### PR TITLE
Rename ORM attribute 'metadata' to 'meta'

### DIFF
--- a/src/cachibot/storage/models/message.py
+++ b/src/cachibot/storage/models/message.py
@@ -34,8 +34,8 @@ class Message(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    metadata: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, server_default="{}"
+    meta: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, server_default="{}"
     )
 
     # Relationships
@@ -62,7 +62,7 @@ class BotMessage(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    metadata: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, server_default="{}"
+    meta: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, server_default="{}"
     )
     reply_to_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/src/cachibot/storage/models/room.py
+++ b/src/cachibot/storage/models/room.py
@@ -143,8 +143,8 @@ class RoomMessage(Base):
     sender_id: Mapped[str] = mapped_column(String, nullable=False)
     sender_name: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    metadata: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, server_default="{}"
+    meta: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, server_default="{}"
     )
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/src/cachibot/storage/repository.py
+++ b/src/cachibot/storage/repository.py
@@ -54,7 +54,7 @@ class MessageRepository:
                 role=message.role.value,
                 content=message.content,
                 timestamp=message.timestamp,
-                metadata=message.metadata,
+                meta=message.metadata,
             )
             session.add(obj)
             await session.commit()
@@ -75,7 +75,7 @@ class MessageRepository:
             role=MessageRole(row.role),
             content=row.content,
             timestamp=row.timestamp,
-            metadata=row.metadata,
+            metadata=row.meta,
         )
 
     async def get_messages(
@@ -99,7 +99,7 @@ class MessageRepository:
                 role=MessageRole(row.role),
                 content=row.content,
                 timestamp=row.timestamp,
-                metadata=row.metadata,
+                metadata=row.meta,
             )
             for row in reversed(rows)  # Return in chronological order
         ]
@@ -216,7 +216,7 @@ class KnowledgeRepository:
                 role=message.role,
                 content=message.content,
                 timestamp=message.timestamp,
-                metadata=message.metadata,
+                meta=message.metadata,
                 reply_to_id=message.reply_to_id,
             )
             session.add(obj)
@@ -249,7 +249,7 @@ class KnowledgeRepository:
                 role=row.role,
                 content=row.content,
                 timestamp=row.timestamp,
-                metadata=row.metadata,
+                metadata=row.meta,
                 reply_to_id=row.reply_to_id,
             )
             for row in reversed(rows)  # Return in chronological order
@@ -278,7 +278,7 @@ class KnowledgeRepository:
                 role=row.role,
                 content=row.content,
                 timestamp=row.timestamp,
-                metadata=row.metadata,
+                metadata=row.meta,
                 reply_to_id=row.reply_to_id,
             )
             for row in reversed(rows)

--- a/src/cachibot/storage/room_repository.py
+++ b/src/cachibot/storage/room_repository.py
@@ -280,7 +280,7 @@ class RoomMessageRepository:
                 sender_id=message.sender_id,
                 sender_name=message.sender_name,
                 content=message.content,
-                metadata=message.metadata,
+                meta=message.metadata,
                 timestamp=message.timestamp,
             )
             session.add(obj)
@@ -336,6 +336,6 @@ class RoomMessageRepository:
             sender_id=row.sender_id,
             sender_name=row.sender_name,
             content=row.content,
-            metadata=row.metadata if row.metadata else {},
+            metadata=row.meta if row.meta else {},
             timestamp=row.timestamp,
         )


### PR DESCRIPTION
Rename model attributes from metadata -> meta (while keeping the DB column name as "metadata") for Message, BotMessage and RoomMessage to avoid conflicts with SQLAlchemy's metadata. Update repository code to set model.meta on insert and to read row.meta when reconstructing returned messages, preserving the external metadata field in returned objects. Changes applied in src/cachibot/storage/models/message.py, src/cachibot/storage/models/room.py, src/cachibot/storage/repository.py and src/cachibot/storage/room_repository.py.