### PR TITLE
Add agent max_depth and improve error logging

### DIFF
--- a/cachibot.example.toml
+++ b/cachibot.example.toml
@@ -24,6 +24,10 @@ temperature = 0.6
 # Higher values allow the agent to write longer files and tool outputs
 max_tokens = 4096
 
+# Maximum nested agent depth (Prompture recursion limit)
+# Prevents infinite sub-agent loops. Default 5 is safe for normal usage.
+# max_depth = 5
+
 [sandbox]
 # Allowed Python imports (safe modules only)
 # Add more as needed, but be careful with security implications

--- a/src/cachibot/agent.py
+++ b/src/cachibot/agent.py
@@ -137,6 +137,7 @@ class CachibotAgent:
             persistent_conversation=True,
             security_context=security_context,
             max_tool_result_length=self.config.agent.max_tool_result_length,
+            max_depth=self.config.agent.max_depth,
             options={
                 "temperature": self.config.agent.temperature,
                 "max_tokens": self.config.agent.max_tokens,

--- a/src/cachibot/api/room_websocket.py
+++ b/src/cachibot/api/room_websocket.py
@@ -398,10 +398,10 @@ async def run_room_bot(
             RoomWSMessage.error(room_id, f"{bot.name} was cancelled", bot_id=bot_id),
         )
     except Exception as e:
-        logger.error(f"Bot {bot_id} error in room {room_id}: {e}")
+        logger.error(f"Bot {bot_id} error in room {room_id}: {e}", exc_info=True)
         await room_manager.send_to_room(
             room_id,
-            RoomWSMessage.error(room_id, f"{bot.name} encountered an error", bot_id=bot_id),
+            RoomWSMessage.error(room_id, f"{bot.name} encountered an error: {e}", bot_id=bot_id),
         )
     finally:
         if orchestrator:

--- a/src/cachibot/api/websocket.py
+++ b/src/cachibot/api/websocket.py
@@ -243,8 +243,8 @@ async def websocket_endpoint(
     except WebSocketDisconnect:
         pass
     except Exception as e:
-        logger.error(f"WebSocket error for client {client_id}: {e}")
-        await manager.send(client_id, WSMessage.error("An internal error occurred"))
+        logger.error(f"WebSocket error for client {client_id}: {e}", exc_info=True)
+        await manager.send(client_id, WSMessage.error(f"An internal error occurred: {e}"))
     finally:
         # Cancel any running task
         if current_task and not current_task.done():
@@ -363,5 +363,5 @@ async def run_agent(
     except asyncio.CancelledError:
         await manager.send(client_id, WSMessage.error("Operation cancelled"))
     except Exception as e:
-        logger.error(f"WebSocket error for client {client_id}: {e}")
-        await manager.send(client_id, WSMessage.error("An internal error occurred"))
+        logger.error(f"Agent error for client {client_id}: {e}", exc_info=True)
+        await manager.send(client_id, WSMessage.error(f"An internal error occurred: {e}"))

--- a/src/cachibot/config.py
+++ b/src/cachibot/config.py
@@ -81,6 +81,7 @@ class AgentConfig:
     temperature: float = 0.6  # Moonshot recommends 0.6 for instant mode
     max_tokens: int = 4096  # Max output tokens per LLM call
     max_tool_result_length: int = 2000  # Truncate large tool results sent to the LLM
+    max_depth: int = 5  # Max nested agent depth (Prompture recursion limit)
 
 
 @dataclass


### PR DESCRIPTION
Introduce a new AgentConfig.max_depth (default 5) to limit nested/sub-agent recursion and prevent infinite loops; expose it as a commented option in cachibot.example.toml and pass it into the agent constructor. Also enhance error handling/logging by including exc_info in logger calls and appending exception details to WebSocket and room error messages for better diagnostics.