### PR TITLE
Unify DB session usage via storage.db

### DIFF
--- a/src/cachibot/storage/__init__.py
+++ b/src/cachibot/storage/__init__.py
@@ -5,7 +5,7 @@ Multi-database storage using SQLAlchemy 2.0 async ORM.
 Supports SQLite (default, zero-config) and PostgreSQL (via DATABASE_URL).
 """
 
-from cachibot.storage.db import async_session_maker, close_db, db_type, get_session, init_db
+from cachibot.storage.db import close_db, get_session, init_db
 from cachibot.storage.repository import (
     BotRepository,
     ChatRepository,
@@ -38,8 +38,6 @@ __all__ = [
     "init_db",
     "close_db",
     "get_session",
-    "async_session_maker",
-    "db_type",
     # Main repositories
     "MessageRepository",
     "JobRepository",

--- a/src/cachibot/storage/database.py
+++ b/src/cachibot/storage/database.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import warnings
 
-from cachibot.storage.db import async_session_maker, close_db, init_db
+from cachibot.storage import db
+from cachibot.storage.db import close_db, init_db
 
 __all__ = ["init_db", "close_db", "get_db"]
 
@@ -24,13 +25,13 @@ async def get_db():
     Returns an async session for callers that still use `get_db()`.
 
     .. deprecated::
-        Use ``async with async_session_maker() as session:`` directly,
+        Use ``async with db.async_session_maker() as session:`` directly,
         or inject via ``get_session()`` from ``cachibot.storage.db``.
     """
     warnings.warn(
-        "get_db() is deprecated. Use async_session_maker() context manager "
+        "get_db() is deprecated. Use db.async_session_maker() context manager "
         "or cachibot.storage.db.get_session() instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return async_session_maker()
+    return db.async_session_maker()

--- a/src/cachibot/storage/repository.py
+++ b/src/cachibot/storage/repository.py
@@ -26,7 +26,7 @@ from cachibot.models.knowledge import (
     NoteSource,
 )
 from cachibot.models.skill import BotSkillActivation, SkillDefinition, SkillSource
-from cachibot.storage.db import async_session_maker
+from cachibot.storage import db
 from cachibot.storage.models.bot import Bot as BotModel
 from cachibot.storage.models.chat import Chat as ChatModel
 from cachibot.storage.models.connection import BotConnection as BotConnectionModel
@@ -55,7 +55,7 @@ class MessageRepository:
 
     async def save_message(self, message: ChatMessage) -> None:
         """Save a message to the database."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = MessageModel(
                 id=message.id,
                 role=message.role.value,
@@ -68,7 +68,7 @@ class MessageRepository:
 
     async def get_message(self, message_id: str) -> ChatMessage | None:
         """Get a message by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(MessageModel).where(MessageModel.id == message_id)
             )
@@ -91,7 +91,7 @@ class MessageRepository:
         offset: int = 0,
     ) -> list[ChatMessage]:
         """Get messages with pagination."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(MessageModel)
                 .order_by(MessageModel.timestamp.desc())
@@ -113,13 +113,13 @@ class MessageRepository:
 
     async def get_message_count(self) -> int:
         """Get total message count."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(func.count()).select_from(MessageModel))
             return result.scalar_one()
 
     async def clear_messages(self) -> None:
         """Delete all messages."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(delete(MessageModel))
             await session.commit()
 
@@ -129,7 +129,7 @@ class JobRepository:
 
     async def save_job(self, job: Job) -> None:
         """Save a job to the database."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = JobModel(
                 id=job.id,
                 status=job.status.value,
@@ -146,7 +146,7 @@ class JobRepository:
 
     async def update_job(self, job: Job) -> None:
         """Update an existing job."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(JobModel)
                 .where(JobModel.id == job.id)
@@ -163,7 +163,7 @@ class JobRepository:
 
     async def get_job(self, job_id: str) -> Job | None:
         """Get a job by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(JobModel).where(JobModel.id == job_id))
             row = result.scalar_one_or_none()
 
@@ -183,7 +183,7 @@ class JobRepository:
             stmt = stmt.where(JobModel.status == status.value)
         stmt = stmt.order_by(JobModel.created_at.desc()).limit(limit)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
 
@@ -211,7 +211,7 @@ class KnowledgeRepository:
 
     async def save_bot_message(self, message: BotMessage) -> None:
         """Save a message to bot's conversation history."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = BotMessageModel(
                 id=message.id,
                 bot_id=message.bot_id,
@@ -232,7 +232,7 @@ class KnowledgeRepository:
         limit: int = 50,
     ) -> list[BotMessage]:
         """Get messages for a specific bot and chat."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotMessageModel)
                 .where(
@@ -264,7 +264,7 @@ class KnowledgeRepository:
         limit: int = 20,
     ) -> list[BotMessage]:
         """Get recent messages across all chats for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotMessageModel)
                 .where(BotMessageModel.bot_id == bot_id)
@@ -289,7 +289,7 @@ class KnowledgeRepository:
 
     async def delete_all_messages_for_bot(self, bot_id: str) -> int:
         """Delete all messages for a bot. Returns number of messages deleted."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(BotMessageModel).where(BotMessageModel.bot_id == bot_id)
             )
@@ -298,7 +298,7 @@ class KnowledgeRepository:
 
     async def delete_messages_for_chat(self, bot_id: str, chat_id: str) -> int:
         """Delete all messages for a specific chat. Returns number deleted."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(BotMessageModel).where(
                     BotMessageModel.bot_id == bot_id,
@@ -310,7 +310,7 @@ class KnowledgeRepository:
 
     async def get_message_count_for_bot(self, bot_id: str) -> int:
         """Get the count of messages for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(func.count())
                 .select_from(BotMessageModel)
@@ -322,7 +322,7 @@ class KnowledgeRepository:
 
     async def get_instructions(self, bot_id: str) -> BotInstruction | None:
         """Get custom instructions for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotInstructionModel).where(BotInstructionModel.bot_id == bot_id)
             )
@@ -345,7 +345,7 @@ class KnowledgeRepository:
         # Try to get existing
         existing = await self.get_instructions(bot_id)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             if existing:
                 await session.execute(
                     update(BotInstructionModel)
@@ -374,7 +374,7 @@ class KnowledgeRepository:
 
     async def delete_instructions(self, bot_id: str) -> bool:
         """Delete instructions for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(BotInstructionModel).where(BotInstructionModel.bot_id == bot_id)
             )
@@ -385,7 +385,7 @@ class KnowledgeRepository:
 
     async def save_document(self, doc: Document) -> None:
         """Save document metadata."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = BotDocumentModel(
                 id=doc.id,
                 bot_id=doc.bot_id,
@@ -403,7 +403,7 @@ class KnowledgeRepository:
 
     async def get_document(self, document_id: str) -> Document | None:
         """Get a document by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotDocumentModel).where(BotDocumentModel.id == document_id)
             )
@@ -416,7 +416,7 @@ class KnowledgeRepository:
 
     async def get_documents_by_bot(self, bot_id: str) -> list[Document]:
         """Get all documents for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotDocumentModel)
                 .where(BotDocumentModel.bot_id == bot_id)
@@ -428,7 +428,7 @@ class KnowledgeRepository:
 
     async def document_exists_by_hash(self, bot_id: str, file_hash: str) -> bool:
         """Check if a document with this hash already exists for the bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotDocumentModel.id).where(
                     BotDocumentModel.bot_id == bot_id,
@@ -449,7 +449,7 @@ class KnowledgeRepository:
         if chunk_count is not None:
             values["chunk_count"] = chunk_count
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(BotDocumentModel).where(BotDocumentModel.id == document_id).values(**values)
             )
@@ -457,7 +457,7 @@ class KnowledgeRepository:
 
     async def delete_document(self, document_id: str) -> bool:
         """Delete a document and its chunks."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             # Chunks deleted via CASCADE
             result = await session.execute(
                 delete(BotDocumentModel).where(BotDocumentModel.id == document_id)
@@ -487,7 +487,7 @@ class KnowledgeRepository:
         if not chunks:
             return
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             session.add_all(
                 [
                     DocChunkModel(
@@ -505,7 +505,7 @@ class KnowledgeRepository:
 
     async def get_chunks_by_document(self, document_id: str) -> list[DocChunk]:
         """Get all chunks for a document."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(DocChunkModel)
                 .where(DocChunkModel.document_id == document_id)
@@ -527,7 +527,7 @@ class KnowledgeRepository:
 
     async def get_all_chunks_by_bot(self, bot_id: str) -> list[DocChunk]:
         """Get all chunks for a bot (for vector search)."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(DocChunkModel)
                 .where(DocChunkModel.bot_id == bot_id)
@@ -549,7 +549,7 @@ class KnowledgeRepository:
 
     async def delete_chunks_by_document(self, document_id: str) -> int:
         """Delete all chunks for a document."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(DocChunkModel).where(DocChunkModel.document_id == document_id)
             )
@@ -560,7 +560,7 @@ class KnowledgeRepository:
 
     async def get_knowledge_stats(self, bot_id: str) -> dict:
         """Get aggregated knowledge stats for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             # Document counts by status
             doc_result = await session.execute(
                 select(BotDocumentModel.status, func.count())
@@ -601,7 +601,7 @@ class KnowledgeRepository:
 
     async def reset_document_for_retry(self, document_id: str) -> bool:
         """Reset a failed document to processing status for retry."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 update(BotDocumentModel)
                 .where(
@@ -619,7 +619,7 @@ class KnowledgeRepository:
 
     async def get_chunks_by_document_light(self, document_id: str) -> list[dict]:
         """Get chunks for a document without embedding BLOBs."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(
                     DocChunkModel.id,
@@ -644,7 +644,7 @@ class KnowledgeRepository:
 
     async def get_all_embeddings_by_bot(self, bot_id: str) -> list[dict]:
         """Get only embedding data for vector search (no content)."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(
                     DocChunkModel.id,
@@ -671,7 +671,7 @@ class KnowledgeRepository:
         if not chunk_ids:
             return []
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(DocChunkModel).where(DocChunkModel.id.in_(chunk_ids))
             )
@@ -695,7 +695,7 @@ class NotesRepository:
 
     async def save_note(self, note: BotNote) -> None:
         """Save a new note."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = BotNoteModel(
                 id=note.id,
                 bot_id=note.bot_id,
@@ -711,7 +711,7 @@ class NotesRepository:
 
     async def get_note(self, note_id: str) -> BotNote | None:
         """Get a note by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(BotNoteModel).where(BotNoteModel.id == note_id))
             row = result.scalar_one_or_none()
         return self._row_to_note(row) if row else None
@@ -754,7 +754,7 @@ class NotesRepository:
 
         stmt = stmt.order_by(BotNoteModel.updated_at.desc()).limit(limit).offset(offset)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
 
@@ -778,7 +778,7 @@ class NotesRepository:
         if tags is not None:
             values["tags"] = tags
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 update(BotNoteModel).where(BotNoteModel.id == note_id).values(**values)
             )
@@ -790,14 +790,14 @@ class NotesRepository:
 
     async def delete_note(self, note_id: str) -> bool:
         """Delete a note by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(BotNoteModel).where(BotNoteModel.id == note_id))
             await session.commit()
             return result.rowcount > 0
 
     async def get_all_tags(self, bot_id: str) -> list[str]:
         """Get all unique tags across all notes for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotNoteModel.tags).where(BotNoteModel.bot_id == bot_id)
             )
@@ -811,7 +811,7 @@ class NotesRepository:
 
     async def search_notes(self, bot_id: str, query: str, limit: int = 10) -> list[BotNote]:
         """Simple text search on title + content."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotNoteModel)
                 .where(
@@ -844,7 +844,7 @@ class ContactsRepository:
 
     async def save_contact(self, contact: Contact) -> None:
         """Save a new contact."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = BotContactModel(
                 id=contact.id,
                 bot_id=contact.bot_id,
@@ -858,7 +858,7 @@ class ContactsRepository:
 
     async def get_contact(self, contact_id: str) -> Contact | None:
         """Get a contact by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotContactModel).where(BotContactModel.id == contact_id)
             )
@@ -867,7 +867,7 @@ class ContactsRepository:
 
     async def get_contacts_by_bot(self, bot_id: str) -> list[Contact]:
         """Get all contacts for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotContactModel)
                 .where(BotContactModel.bot_id == bot_id)
@@ -878,7 +878,7 @@ class ContactsRepository:
 
     async def update_contact(self, contact: Contact) -> None:
         """Update an existing contact."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(BotContactModel)
                 .where(BotContactModel.id == contact.id)
@@ -892,7 +892,7 @@ class ContactsRepository:
 
     async def delete_contact(self, contact_id: str) -> bool:
         """Delete a contact by ID. Returns True if deleted, False if not found."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(BotContactModel).where(BotContactModel.id == contact_id)
             )
@@ -916,7 +916,7 @@ class ConnectionRepository:
 
     async def save_connection(self, connection: BotConnection) -> None:
         """Save a new connection."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = BotConnectionModel(
                 id=connection.id,
                 bot_id=connection.bot_id,
@@ -935,7 +935,7 @@ class ConnectionRepository:
 
     async def get_connection(self, connection_id: str) -> BotConnection | None:
         """Get a connection by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotConnectionModel).where(BotConnectionModel.id == connection_id)
             )
@@ -944,7 +944,7 @@ class ConnectionRepository:
 
     async def get_connections_by_bot(self, bot_id: str) -> list[BotConnection]:
         """Get all connections for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotConnectionModel)
                 .where(BotConnectionModel.bot_id == bot_id)
@@ -955,7 +955,7 @@ class ConnectionRepository:
 
     async def get_all_connected(self) -> list[BotConnection]:
         """Get all connections with 'connected' status."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotConnectionModel).where(
                     BotConnectionModel.status == ConnectionStatus.connected.value
@@ -966,7 +966,7 @@ class ConnectionRepository:
 
     async def update_connection(self, connection: BotConnection) -> None:
         """Update an existing connection."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(BotConnectionModel)
                 .where(BotConnectionModel.id == connection.id)
@@ -990,7 +990,7 @@ class ConnectionRepository:
     ) -> None:
         """Update connection status and optionally error message."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(BotConnectionModel)
                 .where(BotConnectionModel.id == connection_id)
@@ -1005,7 +1005,7 @@ class ConnectionRepository:
     async def increment_message_count(self, connection_id: str) -> None:
         """Increment message count and update last_activity."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(BotConnectionModel)
                 .where(BotConnectionModel.id == connection_id)
@@ -1019,7 +1019,7 @@ class ConnectionRepository:
 
     async def delete_connection(self, connection_id: str) -> bool:
         """Delete a connection by ID. Returns True if deleted, False if not found."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(BotConnectionModel).where(BotConnectionModel.id == connection_id)
             )
@@ -1048,7 +1048,7 @@ class BotRepository:
 
     async def upsert_bot(self, bot: Bot) -> None:
         """Create or update a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             existing = await session.get(BotModel, bot.id)
             if existing:
                 existing.name = bot.name
@@ -1080,21 +1080,21 @@ class BotRepository:
 
     async def get_bot(self, bot_id: str) -> Bot | None:
         """Get a bot by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(BotModel).where(BotModel.id == bot_id))
             row = result.scalar_one_or_none()
             return self._row_to_bot(row) if row else None
 
     async def get_all_bots(self) -> list[Bot]:
         """Get all bots."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(BotModel).order_by(BotModel.name))
             rows = result.scalars().all()
             return [self._row_to_bot(row) for row in rows]
 
     async def delete_bot(self, bot_id: str) -> bool:
         """Delete a bot by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(BotModel).where(BotModel.id == bot_id))
             await session.commit()
             return result.rowcount > 0
@@ -1121,7 +1121,7 @@ class ChatRepository:
 
     async def create_chat(self, chat: Chat) -> None:
         """Create a new chat."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = ChatModel(
                 id=chat.id,
                 bot_id=chat.bot_id,
@@ -1138,7 +1138,7 @@ class ChatRepository:
 
     async def get_chat(self, chat_id: str) -> Chat | None:
         """Get a chat by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(ChatModel).where(ChatModel.id == chat_id))
             row = result.scalar_one_or_none()
             return self._row_to_chat(row) if row else None
@@ -1155,7 +1155,7 @@ class ChatRepository:
 
         Returns None if the chat exists but is archived (won't recreate archived chats).
         """
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(ChatModel).where(
                     ChatModel.bot_id == bot_id,
@@ -1194,14 +1194,14 @@ class ChatRepository:
             stmt = stmt.where(ChatModel.archived.is_(False))
         stmt = stmt.order_by(ChatModel.pinned.desc(), ChatModel.updated_at.desc())
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
             return [self._row_to_chat(row) for row in rows]
 
     async def update_chat(self, chat: Chat) -> None:
         """Update a chat."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(ChatModel)
                 .where(ChatModel.id == chat.id)
@@ -1217,7 +1217,7 @@ class ChatRepository:
     async def archive_chat(self, chat_id: str, archived: bool = True) -> bool:
         """Archive or unarchive a chat. Returns True if chat was found."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 update(ChatModel)
                 .where(ChatModel.id == chat_id)
@@ -1229,7 +1229,7 @@ class ChatRepository:
     async def update_chat_timestamp(self, chat_id: str) -> None:
         """Update the chat's updated_at timestamp."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(ChatModel).where(ChatModel.id == chat_id).values(updated_at=now)
             )
@@ -1237,14 +1237,14 @@ class ChatRepository:
 
     async def delete_chat(self, chat_id: str) -> bool:
         """Delete a chat by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(ChatModel).where(ChatModel.id == chat_id))
             await session.commit()
             return result.rowcount > 0
 
     async def delete_all_chats_for_bot(self, bot_id: str) -> int:
         """Delete all chats for a bot. Returns number of chats deleted."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(ChatModel).where(ChatModel.bot_id == bot_id))
             await session.commit()
             return result.rowcount
@@ -1273,7 +1273,7 @@ class SkillsRepository:
         """Create or update a skill definition."""
         now = datetime.now(timezone.utc)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             existing = await session.get(SkillModel, skill.id)
             if existing:
                 existing.name = skill.name
@@ -1307,21 +1307,21 @@ class SkillsRepository:
 
     async def get_skill(self, skill_id: str) -> SkillDefinition | None:
         """Get a skill by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(SkillModel).where(SkillModel.id == skill_id))
             row = result.scalar_one_or_none()
             return self._row_to_skill(row) if row else None
 
     async def get_all_skills(self) -> list[SkillDefinition]:
         """Get all skill definitions."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(SkillModel).order_by(SkillModel.name))
             rows = result.scalars().all()
             return [self._row_to_skill(row) for row in rows]
 
     async def get_skills_by_source(self, source: SkillSource) -> list[SkillDefinition]:
         """Get skills filtered by source."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(SkillModel)
                 .where(SkillModel.source == source.value)
@@ -1332,7 +1332,7 @@ class SkillsRepository:
 
     async def delete_skill(self, skill_id: str) -> bool:
         """Delete a skill by ID. Also removes all bot activations."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(SkillModel).where(SkillModel.id == skill_id))
             await session.commit()
             return result.rowcount > 0
@@ -1356,7 +1356,7 @@ class SkillsRepository:
 
     async def get_bot_skills(self, bot_id: str) -> list[str]:
         """Get list of enabled skill IDs for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotSkillModel.skill_id).where(
                     BotSkillModel.bot_id == bot_id,
@@ -1367,7 +1367,7 @@ class SkillsRepository:
 
     async def get_bot_skill_definitions(self, bot_id: str) -> list[SkillDefinition]:
         """Get full skill definitions for all enabled skills of a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(SkillModel)
                 .join(BotSkillModel, SkillModel.id == BotSkillModel.skill_id)
@@ -1384,7 +1384,7 @@ class SkillsRepository:
         """Activate a skill for a bot."""
         now = datetime.now(timezone.utc)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             existing = await session.get(BotSkillModel, (bot_id, skill_id))
             if existing:
                 existing.enabled = True
@@ -1402,7 +1402,7 @@ class SkillsRepository:
 
     async def deactivate_skill(self, bot_id: str, skill_id: str) -> bool:
         """Deactivate a skill for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(BotSkillModel).where(
                     BotSkillModel.bot_id == bot_id,
@@ -1414,7 +1414,7 @@ class SkillsRepository:
 
     async def is_skill_activated(self, bot_id: str, skill_id: str) -> bool:
         """Check if a skill is activated for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotSkillModel.bot_id).where(
                     BotSkillModel.bot_id == bot_id,
@@ -1426,7 +1426,7 @@ class SkillsRepository:
 
     async def get_skill_activation(self, bot_id: str, skill_id: str) -> BotSkillActivation | None:
         """Get activation details for a bot/skill pair."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(BotSkillModel).where(
                     BotSkillModel.bot_id == bot_id,

--- a/src/cachibot/storage/room_repository.py
+++ b/src/cachibot/storage/room_repository.py
@@ -18,7 +18,7 @@ from cachibot.models.room import (
     RoomSenderType,
     RoomSettings,
 )
-from cachibot.storage.db import async_session_maker
+from cachibot.storage import db
 from cachibot.storage.models.bot import Bot as BotModel
 from cachibot.storage.models.room import (
     Room as RoomModel,
@@ -40,7 +40,7 @@ class RoomRepository:
 
     async def create_room(self, room: Room) -> None:
         """Create a new room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = RoomModel(
                 id=room.id,
                 title=room.title,
@@ -56,7 +56,7 @@ class RoomRepository:
 
     async def get_room(self, room_id: str) -> Room | None:
         """Get a room by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(RoomModel).where(RoomModel.id == room_id))
             row = result.scalar_one_or_none()
         if row is None:
@@ -65,7 +65,7 @@ class RoomRepository:
 
     async def get_rooms_for_user(self, user_id: str) -> list[Room]:
         """Get all rooms a user is a member of."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(RoomModel)
                 .join(RoomMemberModel, RoomModel.id == RoomMemberModel.room_id)
@@ -93,7 +93,7 @@ class RoomRepository:
         if settings is not None:
             values["settings"] = settings.model_dump()
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 update(RoomModel).where(RoomModel.id == room_id).values(**values)
             )
@@ -105,7 +105,7 @@ class RoomRepository:
 
     async def delete_room(self, room_id: str) -> bool:
         """Delete a room (cascades to members, bots, messages)."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(RoomModel).where(RoomModel.id == room_id))
             await session.commit()
             return result.rowcount > 0
@@ -130,7 +130,7 @@ class RoomMemberRepository:
 
     async def add_member(self, member: RoomMember) -> None:
         """Add a member to a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = RoomMemberModel(
                 room_id=member.room_id,
                 user_id=member.user_id,
@@ -142,7 +142,7 @@ class RoomMemberRepository:
 
     async def remove_member(self, room_id: str, user_id: str) -> bool:
         """Remove a member from a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(RoomMemberModel).where(
                     RoomMemberModel.room_id == room_id,
@@ -154,7 +154,7 @@ class RoomMemberRepository:
 
     async def get_members(self, room_id: str) -> list[RoomMember]:
         """Get all members of a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(
                     RoomMemberModel.room_id,
@@ -181,7 +181,7 @@ class RoomMemberRepository:
 
     async def is_member(self, room_id: str, user_id: str) -> bool:
         """Check if a user is a member of a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(RoomMemberModel.room_id).where(
                     RoomMemberModel.room_id == room_id,
@@ -192,7 +192,7 @@ class RoomMemberRepository:
 
     async def get_member_role(self, room_id: str, user_id: str) -> RoomMemberRole | None:
         """Get a user's role in a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(RoomMemberModel.role).where(
                     RoomMemberModel.room_id == room_id,
@@ -210,7 +210,7 @@ class RoomBotRepository:
 
     async def add_bot(self, room_bot: RoomBot) -> None:
         """Add a bot to a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = RoomBotModel(
                 room_id=room_bot.room_id,
                 bot_id=room_bot.bot_id,
@@ -221,7 +221,7 @@ class RoomBotRepository:
 
     async def remove_bot(self, room_id: str, bot_id: str) -> bool:
         """Remove a bot from a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(RoomBotModel).where(
                     RoomBotModel.room_id == room_id,
@@ -233,7 +233,7 @@ class RoomBotRepository:
 
     async def get_bots(self, room_id: str) -> list[RoomBot]:
         """Get all bots in a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(
                     RoomBotModel.room_id,
@@ -258,7 +258,7 @@ class RoomBotRepository:
 
     async def get_bot_count(self, room_id: str) -> int:
         """Get the number of bots in a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(func.count())
                 .select_from(RoomBotModel)
@@ -272,7 +272,7 @@ class RoomMessageRepository:
 
     async def save_message(self, message: RoomMessage) -> None:
         """Save a message to the room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = RoomMessageModel(
                 id=message.id,
                 room_id=message.room_id,
@@ -302,7 +302,7 @@ class RoomMessageRepository:
 
         stmt = stmt.order_by(RoomMessageModel.timestamp.desc()).limit(limit)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
 
@@ -310,7 +310,7 @@ class RoomMessageRepository:
 
     async def get_message_count(self, room_id: str) -> int:
         """Get the number of messages in a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(func.count())
                 .select_from(RoomMessageModel)
@@ -320,7 +320,7 @@ class RoomMessageRepository:
 
     async def delete_messages(self, room_id: str) -> int:
         """Delete all messages in a room."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(RoomMessageModel).where(RoomMessageModel.room_id == room_id)
             )

--- a/src/cachibot/storage/work_repository.py
+++ b/src/cachibot/storage/work_repository.py
@@ -26,7 +26,7 @@ from cachibot.models.work import (
     Work,
     WorkStatus,
 )
-from cachibot.storage.db import async_session_maker
+from cachibot.storage import db
 from cachibot.storage.models.work import (
     Function as FunctionModel,
 )
@@ -52,7 +52,7 @@ class FunctionRepository:
 
     async def save(self, fn: BotFunction) -> None:
         """Save a new function."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = FunctionModel(
                 id=fn.id,
                 bot_id=fn.bot_id,
@@ -73,7 +73,7 @@ class FunctionRepository:
 
     async def update(self, fn: BotFunction) -> None:
         """Update an existing function."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(FunctionModel)
                 .where(FunctionModel.id == fn.id)
@@ -94,7 +94,7 @@ class FunctionRepository:
 
     async def get(self, function_id: str) -> BotFunction | None:
         """Get a function by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(FunctionModel).where(FunctionModel.id == function_id)
             )
@@ -103,7 +103,7 @@ class FunctionRepository:
 
     async def get_by_bot(self, bot_id: str) -> list[BotFunction]:
         """Get all functions for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(FunctionModel)
                 .where(FunctionModel.bot_id == bot_id)
@@ -114,7 +114,7 @@ class FunctionRepository:
 
     async def delete(self, function_id: str) -> bool:
         """Delete a function by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(FunctionModel).where(FunctionModel.id == function_id)
             )
@@ -125,7 +125,7 @@ class FunctionRepository:
         """Increment run count and update success rate."""
         now = datetime.now(timezone.utc)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             # Get current stats
             result = await session.execute(
                 select(FunctionModel.run_count, FunctionModel.success_rate).where(
@@ -203,7 +203,7 @@ class ScheduleRepository:
 
     async def save(self, schedule: Schedule) -> None:
         """Save a new schedule."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = ScheduleModel(
                 id=schedule.id,
                 bot_id=schedule.bot_id,
@@ -231,7 +231,7 @@ class ScheduleRepository:
 
     async def update(self, schedule: Schedule) -> None:
         """Update an existing schedule."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(ScheduleModel)
                 .where(ScheduleModel.id == schedule.id)
@@ -259,7 +259,7 @@ class ScheduleRepository:
 
     async def get(self, schedule_id: str) -> Schedule | None:
         """Get a schedule by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(ScheduleModel).where(ScheduleModel.id == schedule_id)
             )
@@ -268,7 +268,7 @@ class ScheduleRepository:
 
     async def get_by_bot(self, bot_id: str) -> list[Schedule]:
         """Get all schedules for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(ScheduleModel)
                 .where(ScheduleModel.bot_id == bot_id)
@@ -280,7 +280,7 @@ class ScheduleRepository:
     async def get_due_schedules(self) -> list[Schedule]:
         """Get all enabled schedules that are due to run."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(ScheduleModel)
                 .where(
@@ -296,7 +296,7 @@ class ScheduleRepository:
     async def toggle_enabled(self, schedule_id: str, enabled: bool) -> None:
         """Enable or disable a schedule."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(ScheduleModel)
                 .where(ScheduleModel.id == schedule_id)
@@ -307,7 +307,7 @@ class ScheduleRepository:
     async def update_next_run(self, schedule_id: str, next_run_at: datetime | None) -> None:
         """Update the next run time for a schedule."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(ScheduleModel)
                 .where(ScheduleModel.id == schedule_id)
@@ -318,7 +318,7 @@ class ScheduleRepository:
     async def record_run(self, schedule_id: str) -> None:
         """Record that a schedule has run."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(ScheduleModel)
                 .where(ScheduleModel.id == schedule_id)
@@ -332,7 +332,7 @@ class ScheduleRepository:
 
     async def delete(self, schedule_id: str) -> bool:
         """Delete a schedule by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 delete(ScheduleModel).where(ScheduleModel.id == schedule_id)
             )
@@ -370,7 +370,7 @@ class WorkRepository:
 
     async def save(self, work: Work) -> None:
         """Save a new work item."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = WorkModel(
                 id=work.id,
                 bot_id=work.bot_id,
@@ -398,7 +398,7 @@ class WorkRepository:
 
     async def update(self, work: Work) -> None:
         """Update an existing work item."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(WorkModel)
                 .where(WorkModel.id == work.id)
@@ -436,13 +436,13 @@ class WorkRepository:
             values["completed_at"] = now
             values["error"] = error
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(update(WorkModel).where(WorkModel.id == work_id).values(**values))
             await session.commit()
 
     async def update_progress(self, work_id: str, progress: float) -> None:
         """Update work progress."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(WorkModel).where(WorkModel.id == work_id).values(progress=progress)
             )
@@ -450,7 +450,7 @@ class WorkRepository:
 
     async def get(self, work_id: str) -> Work | None:
         """Get a work item by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(WorkModel).where(WorkModel.id == work_id))
             row = result.scalar_one_or_none()
         return self._row_to_work(row) if row else None
@@ -467,14 +467,14 @@ class WorkRepository:
             stmt = stmt.where(WorkModel.status == status.value)
         stmt = stmt.order_by(WorkModel.created_at.desc()).limit(limit)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
         return [self._row_to_work(row) for row in rows]
 
     async def get_active(self, bot_id: str) -> list[Work]:
         """Get active (pending/in_progress) work for a bot."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(WorkModel)
                 .where(
@@ -488,7 +488,7 @@ class WorkRepository:
 
     async def get_by_schedule(self, schedule_id: str) -> list[Work]:
         """Get work items created by a schedule."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(WorkModel)
                 .where(WorkModel.schedule_id == schedule_id)
@@ -499,7 +499,7 @@ class WorkRepository:
 
     async def get_children(self, parent_work_id: str) -> list[Work]:
         """Get child work items."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(WorkModel)
                 .where(WorkModel.parent_work_id == parent_work_id)
@@ -510,7 +510,7 @@ class WorkRepository:
 
     async def delete(self, work_id: str) -> bool:
         """Delete a work item (cascades to tasks and jobs)."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(WorkModel).where(WorkModel.id == work_id))
             await session.commit()
             return result.rowcount > 0
@@ -546,7 +546,7 @@ class TaskRepository:
 
     async def save(self, task: Task) -> None:
         """Save a new task."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = TaskModel(
                 id=task.id,
                 bot_id=task.bot_id,
@@ -575,7 +575,7 @@ class TaskRepository:
         """Save multiple tasks at once."""
         if not tasks:
             return
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             session.add_all(
                 [
                     TaskModel(
@@ -606,7 +606,7 @@ class TaskRepository:
 
     async def update(self, task: Task) -> None:
         """Update an existing task."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(TaskModel)
                 .where(TaskModel.id == task.id)
@@ -647,13 +647,13 @@ class TaskRepository:
             values["error"] = error
             values["result"] = result
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(update(TaskModel).where(TaskModel.id == task_id).values(**values))
             await session.commit()
 
     async def increment_retry(self, task_id: str) -> int:
         """Increment retry count and return new value."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(TaskModel)
                 .where(TaskModel.id == task_id)
@@ -669,14 +669,14 @@ class TaskRepository:
 
     async def get(self, task_id: str) -> Task | None:
         """Get a task by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(TaskModel).where(TaskModel.id == task_id))
             row = result.scalar_one_or_none()
         return self._row_to_task(row) if row else None
 
     async def get_by_work(self, work_id: str) -> list[Task]:
         """Get all tasks for a work item."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(TaskModel)
                 .where(TaskModel.work_id == work_id)
@@ -715,14 +715,14 @@ class TaskRepository:
             stmt = stmt.where(TaskModel.status == status.value)
         stmt = stmt.order_by(TaskModel.created_at.desc()).limit(limit)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
         return [self._row_to_task(row) for row in rows]
 
     async def delete(self, task_id: str) -> bool:
         """Delete a task (cascades to jobs)."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(TaskModel).where(TaskModel.id == task_id))
             await session.commit()
             return result.rowcount > 0
@@ -757,7 +757,7 @@ class WorkJobRepository:
 
     async def save(self, job: Job) -> None:
         """Save a new job."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = WorkJobModel(
                 id=job.id,
                 bot_id=job.bot_id,
@@ -779,7 +779,7 @@ class WorkJobRepository:
 
     async def update(self, job: Job) -> None:
         """Update an existing job."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(WorkJobModel)
                 .where(WorkJobModel.id == job.id)
@@ -813,7 +813,7 @@ class WorkJobRepository:
             values["error"] = error
             values["result"] = result
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(WorkJobModel).where(WorkJobModel.id == job_id).values(**values)
             )
@@ -821,7 +821,7 @@ class WorkJobRepository:
 
     async def update_progress(self, job_id: str, progress: float) -> None:
         """Update job progress."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(WorkJobModel).where(WorkJobModel.id == job_id).values(progress=progress)
             )
@@ -835,7 +835,7 @@ class WorkJobRepository:
         data: any = None,
     ) -> None:
         """Append a log entry to a job."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             # Get current logs
             result = await session.execute(
                 select(WorkJobModel.logs).where(WorkJobModel.id == job_id)
@@ -860,14 +860,14 @@ class WorkJobRepository:
 
     async def get(self, job_id: str) -> Job | None:
         """Get a job by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(WorkJobModel).where(WorkJobModel.id == job_id))
             row = result.scalar_one_or_none()
         return self._row_to_job(row) if row else None
 
     async def get_by_task(self, task_id: str) -> list[Job]:
         """Get all jobs for a task."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(WorkJobModel)
                 .where(WorkJobModel.task_id == task_id)
@@ -878,7 +878,7 @@ class WorkJobRepository:
 
     async def get_by_work(self, work_id: str) -> list[Job]:
         """Get all jobs for a work item."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(WorkJobModel)
                 .where(WorkJobModel.work_id == work_id)
@@ -889,7 +889,7 @@ class WorkJobRepository:
 
     async def get_latest_for_task(self, task_id: str) -> Job | None:
         """Get the latest job for a task."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(WorkJobModel)
                 .where(WorkJobModel.task_id == task_id)
@@ -906,14 +906,14 @@ class WorkJobRepository:
             stmt = stmt.where(WorkJobModel.bot_id == bot_id)
         stmt = stmt.order_by(WorkJobModel.started_at.asc())
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
         return [self._row_to_job(row) for row in rows]
 
     async def delete(self, job_id: str) -> bool:
         """Delete a job."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(WorkJobModel).where(WorkJobModel.id == job_id))
             await session.commit()
             return result.rowcount > 0
@@ -943,7 +943,7 @@ class TodoRepository:
 
     async def save(self, todo: Todo) -> None:
         """Save a new todo."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             obj = TodoModel(
                 id=todo.id,
                 bot_id=todo.bot_id,
@@ -964,7 +964,7 @@ class TodoRepository:
 
     async def update(self, todo: Todo) -> None:
         """Update an existing todo."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(TodoModel)
                 .where(TodoModel.id == todo.id)
@@ -992,7 +992,7 @@ class TodoRepository:
         else:
             values["completed_at"] = None
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(update(TodoModel).where(TodoModel.id == todo_id).values(**values))
             await session.commit()
 
@@ -1004,7 +1004,7 @@ class TodoRepository:
     ) -> None:
         """Mark a todo as converted to work or task."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             await session.execute(
                 update(TodoModel)
                 .where(TodoModel.id == todo_id)
@@ -1019,7 +1019,7 @@ class TodoRepository:
 
     async def get(self, todo_id: str) -> Todo | None:
         """Get a todo by ID."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(select(TodoModel).where(TodoModel.id == todo_id))
             row = result.scalar_one_or_none()
         return self._row_to_todo(row) if row else None
@@ -1036,7 +1036,7 @@ class TodoRepository:
             stmt = stmt.where(TodoModel.status == status.value)
         stmt = stmt.order_by(TodoModel.priority.desc(), TodoModel.created_at.desc()).limit(limit)
 
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
         return [self._row_to_todo(row) for row in rows]
@@ -1048,7 +1048,7 @@ class TodoRepository:
     async def get_due_reminders(self) -> list[Todo]:
         """Get todos with reminders that are due."""
         now = datetime.now(timezone.utc)
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(
                 select(TodoModel)
                 .where(
@@ -1063,7 +1063,7 @@ class TodoRepository:
 
     async def delete(self, todo_id: str) -> bool:
         """Delete a todo."""
-        async with async_session_maker() as session:
+        async with db.async_session_maker() as session:
             result = await session.execute(delete(TodoModel).where(TodoModel.id == todo_id))
             await session.commit()
             return result.rowcount > 0


### PR DESCRIPTION
Replace direct imports of async_session_maker/db_type with a single storage.db namespace across repositories. Files now import cachibot.storage.db as db and use db.async_session_maker (and db.db_type where needed). storage.__init__ no longer re-exports async_session_maker/db_type and get_db() deprecation message updated to reference db.async_session_maker. This centralizes DB session access and cleans up the storage public API.