### PR TITLE
Use FK with cascade for BotOwnership.bot_id

### DIFF
--- a/src/cachibot/storage/models/bot.py
+++ b/src/cachibot/storage/models/bot.py
@@ -60,7 +60,12 @@ class BotOwnership(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("bots.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
     user_id: Mapped[str] = mapped_column(
         String,
         ForeignKey("users.id", ondelete="CASCADE"),
@@ -72,9 +77,4 @@ class BotOwnership(Base):
 
     # Relationships
     user: Mapped[User] = relationship("User", back_populates="bot_ownerships")
-    bot: Mapped[Bot] = relationship(
-        "Bot",
-        back_populates="ownership",
-        primaryjoin="BotOwnership.bot_id == Bot.id",
-        foreign_keys=[bot_id],
-    )
+    bot: Mapped[Bot] = relationship("Bot", back_populates="ownership")


### PR DESCRIPTION
Make bot_id a proper ForeignKey to bots.id with ondelete='CASCADE' (unique, non-null) and simplify the relationship to use the default back_populates mapping. This enforces referential integrity and ensures ownership rows are removed when a Bot is deleted; it also removes the explicit primaryjoin/foreign_keys configuration.