### PR TITLE
Add FK constraints to various storage models

### DIFF
--- a/src/cachibot/storage/models/chat.py
+++ b/src/cachibot/storage/models/chat.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Index, String, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from cachibot.storage.db import Base
@@ -34,7 +34,9 @@ class Chat(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     platform: Mapped[str | None] = mapped_column(String, nullable=True)
     platform_chat_id: Mapped[str | None] = mapped_column(String, nullable=True)
@@ -48,9 +50,4 @@ class Chat(Base):
     )
 
     # Relationships
-    bot: Mapped[Bot] = relationship(
-        "Bot",
-        back_populates="chats",
-        primaryjoin="Chat.bot_id == Bot.id",
-        foreign_keys=[bot_id],
-    )
+    bot: Mapped[Bot] = relationship("Bot", back_populates="chats")

--- a/src/cachibot/storage/models/connection.py
+++ b/src/cachibot/storage/models/connection.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 
 import sqlalchemy as sa
-from sqlalchemy import DateTime, Index, Integer, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from cachibot.storage.db import Base
@@ -25,7 +25,9 @@ class BotConnection(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     platform: Mapped[str] = mapped_column(String, nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False, server_default="disconnected")

--- a/src/cachibot/storage/models/contact.py
+++ b/src/cachibot/storage/models/contact.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Index, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from cachibot.storage.db import Base
@@ -21,7 +21,9 @@ class BotContact(Base):
     __table_args__ = (Index("idx_bot_contacts_bot", "bot_id"),)
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     name: Mapped[str] = mapped_column(String, nullable=False)
     details: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/src/cachibot/storage/models/knowledge.py
+++ b/src/cachibot/storage/models/knowledge.py
@@ -68,7 +68,9 @@ class BotInstruction(Base):
     __tablename__ = "bot_instructions"
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
@@ -85,7 +87,9 @@ class BotDocument(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     filename: Mapped[str] = mapped_column(String, nullable=False)
     file_type: Mapped[str] = mapped_column(String, nullable=False)
     file_hash: Mapped[str] = mapped_column(String, nullable=False)
@@ -125,7 +129,9 @@ class DocChunk(Base):
         ForeignKey("bot_documents.id", ondelete="CASCADE"),
         nullable=False,
     )
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     chunk_index: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     embedding = mapped_column(VectorType(384), nullable=True)
@@ -141,7 +147,9 @@ class BotNote(Base):
     __table_args__ = (Index("idx_bot_notes_bot", "bot_id"),)
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     tags: Mapped[list] = mapped_column(sa.JSON, nullable=False, server_default="[]")

--- a/src/cachibot/storage/models/message.py
+++ b/src/cachibot/storage/models/message.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import DateTime, Index, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from cachibot.storage.db import Base
@@ -47,8 +47,12 @@ class BotMessage(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
-    chat_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
+    chat_id: Mapped[str] = mapped_column(
+        String, ForeignKey("chats.id", ondelete="CASCADE"), nullable=False
+    )
     role: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     timestamp: Mapped[datetime] = mapped_column(

--- a/src/cachibot/storage/models/room.py
+++ b/src/cachibot/storage/models/room.py
@@ -98,7 +98,9 @@ class RoomBot(Base):
         ForeignKey("rooms.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    bot_id: Mapped[str] = mapped_column(String, primary_key=True)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), primary_key=True
+    )
     added_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/src/cachibot/storage/models/skill.py
+++ b/src/cachibot/storage/models/skill.py
@@ -53,7 +53,9 @@ class BotSkill(Base):
         Index("idx_bot_skills_skill", "skill_id"),
     )
 
-    bot_id: Mapped[str] = mapped_column(String, primary_key=True)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), primary_key=True
+    )
     skill_id: Mapped[str] = mapped_column(
         String,
         ForeignKey("skills.id", ondelete="CASCADE"),

--- a/src/cachibot/storage/models/work.py
+++ b/src/cachibot/storage/models/work.py
@@ -35,7 +35,9 @@ class Function(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     version: Mapped[str] = mapped_column(String, nullable=False, server_default="1.0.0")
@@ -68,7 +70,9 @@ class Schedule(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     function_id: Mapped[str | None] = mapped_column(
@@ -114,8 +118,12 @@ class Work(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
-    chat_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
+    chat_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     goal: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -184,13 +192,17 @@ class Task(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     work_id: Mapped[str] = mapped_column(
         String,
         ForeignKey("work.id", ondelete="CASCADE"),
         nullable=False,
     )
-    chat_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    chat_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     action: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -234,7 +246,9 @@ class WorkJob(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
     task_id: Mapped[str] = mapped_column(
         String,
         ForeignKey("tasks.id", ondelete="CASCADE"),
@@ -245,7 +259,9 @@ class WorkJob(Base):
         ForeignKey("work.id", ondelete="CASCADE"),
         nullable=False,
     )
-    chat_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    chat_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
+    )
     status: Mapped[str] = mapped_column(String, nullable=False, server_default="pending")
     attempt: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
     progress: Mapped[float] = mapped_column(Float, nullable=False, server_default="0.0")
@@ -274,8 +290,12 @@ class Todo(Base):
     )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    bot_id: Mapped[str] = mapped_column(String, nullable=False)
-    chat_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    bot_id: Mapped[str] = mapped_column(
+        String, ForeignKey("bots.id", ondelete="CASCADE"), nullable=False
+    )
+    chat_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String, nullable=False, server_default="open")


### PR DESCRIPTION
Add ForeignKey imports and constraints across multiple ORM models to enforce referential integrity and cascading behavior. Updated models: chat, connection, contact, knowledge (instructions, documents, docchunks, notes), message, room, skill, and work (Function, Schedule, Work, Task, WorkJob, Todo). Bot-related foreign keys now use ondelete=CASCADE; chat references generally use ondelete=SET NULL where appropriate. Also simplified the Chat.bot relationship by removing the explicit primaryjoin/foreign_keys arguments.