### PR TITLE
Add npm ci fallback to npm install in workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: |
-          npm ci
+          npm ci || npm install
           npm run build
 
       - name: Setup Python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: |
-          npm ci
+          npm ci || npm install
           npm run build
 
       - name: Setup Python
@@ -188,7 +188,7 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: |
-          npm ci
+          npm ci || npm install
           npm run build
 
       - uses: actions/setup-python@v5
@@ -264,7 +264,7 @@ jobs:
 
       - name: Install Electron dependencies
         working-directory: desktop
-        run: npm ci
+        run: npm ci || npm install
 
       - name: Download backend binary
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Add a fallback to `npm install` when `npm ci` fails in GitHub Actions workflows. Updated .github/workflows/dev.yml and .github/workflows/publish.yml to use `npm ci || npm install` for frontend build steps and the desktop install step so builds continue if `npm ci` errors.