### PR TITLE
Update desktop package.json metadata & mac targets

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,6 +7,7 @@
     "name": "Juan Denis",
     "email": "juan@vene.co"
   },
+  "homepage": "https://cachibot.ai",
   "license": "MIT",
   "scripts": {
     "start": "electron .",
@@ -55,8 +56,8 @@
     },
     "mac": {
       "target": [
-        { "target": "dmg", "arch": ["universal"] },
-        { "target": "zip", "arch": ["universal"] }
+        { "target": "dmg" },
+        { "target": "zip" }
       ],
       "icon": "../assets/hero.png",
       "artifactName": "CachiBot-${version}-mac.${ext}",
@@ -77,7 +78,8 @@
     "publish": {
       "provider": "github",
       "owner": "jhd3197",
-      "repo": "cachibot"
+      "repo": "cachibot",
+      "releaseType": "release"
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ cachibot = "cachibot.cli:app"
 cachi = "cachibot.cli:app"
 
 [project.urls]
-Homepage = "https://cachibot.com"
-Documentation = "https://cachibot.com/docs"
+Homepage = "https://cachibot.ai"
+Documentation = "https://cachibot.ai/docs"
 Repository = "https://github.com/jhd3197/cachibot"
 Issues = "https://github.com/jhd3197/cachibot/issues"
 


### PR DESCRIPTION
Add homepage URL, simplify mac build targets, and set publish release type. This commit adds a homepage entry, removes the explicit "universal" arch from the mac dmg/zip targets (allowing default arch handling), and sets "publish.releaseType" to "release" for GitHub publishing.