### PR TITLE
Conditional macOS code signing in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -276,11 +276,11 @@ jobs:
         if: matrix.platform != 'win'
         run: chmod +x build/backend/cachibot-server
 
-      # macOS code signing
+      # macOS code signing (only if certificate secret is configured)
       - name: Import macOS certificates
-        if: matrix.platform == 'mac'
+        if: matrix.platform == 'mac' && secrets.MAC_CERTS_P12 != ''
+        id: mac_certs
         uses: apple-actions/import-codesign-certs@v2
-        continue-on-error: true
         with:
           p12-file-base64: ${{ secrets.MAC_CERTS_P12 }}
           p12-password: ${{ secrets.MAC_CERTS_PASSWORD }}
@@ -291,6 +291,7 @@ jobs:
         run: npx electron-builder --${{ matrix.platform }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ (matrix.platform == 'mac' && secrets.MAC_CERTS_P12 != '') || matrix.platform == 'win' }}
           CSC_LINK: ${{ matrix.platform == 'win' && secrets.WIN_CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
           APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}


### PR DESCRIPTION
Update the publish workflow to only import macOS code signing certificates when the MAC_CERTS_P12 secret is configured. Add an if check on the import step and set an id, remove the unconditional continue-on-error, and set CSC_IDENTITY_AUTO_DISCOVERY to enable automatic identity discovery only on mac when certs are provided or on Windows. This prevents unnecessary/signing failures on mac runners when no certificate is supplied and ensures electron-builder picks the correct signing behavior.