### PR TITLE
Gracefully skip mac code signing when no secrets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -276,11 +276,12 @@ jobs:
         if: matrix.platform != 'win'
         run: chmod +x build/backend/cachibot-server
 
-      # macOS code signing (only if certificate secret is configured)
+      # macOS code signing (skipped gracefully if secrets are not configured)
       - name: Import macOS certificates
-        if: matrix.platform == 'mac' && secrets.MAC_CERTS_P12 != ''
+        if: matrix.platform == 'mac'
         id: mac_certs
         uses: apple-actions/import-codesign-certs@v2
+        continue-on-error: true
         with:
           p12-file-base64: ${{ secrets.MAC_CERTS_P12 }}
           p12-password: ${{ secrets.MAC_CERTS_PASSWORD }}
@@ -291,7 +292,7 @@ jobs:
         run: npx electron-builder --${{ matrix.platform }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ (matrix.platform == 'mac' && secrets.MAC_CERTS_P12 != '') || matrix.platform == 'win' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.mac_certs.outcome == 'success' || matrix.platform != 'mac' }}
           CSC_LINK: ${{ matrix.platform == 'win' && secrets.WIN_CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
           APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}


### PR DESCRIPTION
Run the macOS certificate import step on mac runners but allow it to fail without failing the job (continue-on-error). Simplify the step condition to matrix.platform == 'mac' and change CSC_IDENTITY_AUTO_DISCOVERY to depend on the import step outcome (success) or non-mac platforms. This prevents CI failures when MAC_CERTS_P12/related secrets are not configured and makes code-signing detection more robust.