### PR TITLE
Disable macOS code signing in CI and app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev]
   pull_request:
     branches: [dev, main]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -276,25 +276,12 @@ jobs:
         if: matrix.platform != 'win'
         run: chmod +x build/backend/cachibot-server
 
-      # macOS code signing (skipped gracefully if secrets are not configured)
-      - name: Import macOS certificates
-        if: matrix.platform == 'mac'
-        id: mac_certs
-        uses: apple-actions/import-codesign-certs@v2
-        continue-on-error: true
-        with:
-          p12-file-base64: ${{ secrets.MAC_CERTS_P12 }}
-          p12-password: ${{ secrets.MAC_CERTS_PASSWORD }}
-
       # Build and upload to the GitHub Release
       - name: Build Electron app
         working-directory: desktop
         run: npx electron-builder --${{ matrix.platform }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.mac_certs.outcome == 'success' || matrix.platform != 'mac' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
           CSC_LINK: ${{ matrix.platform == 'win' && secrets.WIN_CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
-          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -60,11 +60,7 @@
         { "target": "zip" }
       ],
       "icon": "../assets/hero.png",
-      "artifactName": "CachiBot-${version}-mac.${ext}",
-      "hardenedRuntime": true,
-      "gatekeeperAssess": false,
-      "entitlements": "../build/entitlements.mac.plist",
-      "entitlementsInherit": "../build/entitlements.mac.plist"
+      "artifactName": "CachiBot-${version}-mac.${ext}"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
Remove macOS code signing from the release workflow and mac build config. The GitHub Actions step that imported macOS certificates was removed and CSC_IDENTITY_AUTO_DISCOVERY is set to false (APPLE_* env vars also removed). In desktop/package.json the mac-specific signing options (hardenedRuntime, gatekeeperAssess, entitlements, entitlementsInherit) were removed, leaving only the artifactName. This results in unsigned macOS builds from CI.