### PR TITLE
Use bash shell for Electron build step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -279,6 +279,7 @@ jobs:
       # Build and upload to the GitHub Release (unsigned)
       - name: Build Electron app
         working-directory: desktop
+        shell: bash
         run: |
           unset CSC_LINK CSC_KEY_PASSWORD
           npx electron-builder --${{ matrix.platform }} --publish always


### PR DESCRIPTION
Add `shell: bash` to the 'Build Electron app' step in .github/workflows/publish.yml so the multi-line run script (including `unset CSC_LINK CSC_KEY_PASSWORD`) is executed with bash semantics. This ensures consistent shell behavior across runners and prevents shell-related issues during the Electron build and publish process.