### PR TITLE
Add anonymous telemetry & consent flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [dev, main]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/cachibot.example.toml
+++ b/cachibot.example.toml
@@ -101,3 +101,11 @@ show_cost = true
 
 # Output style: "detailed" or "compact"
 style = "detailed"
+
+[telemetry]
+# Enable anonymous usage analytics (opt-in, default: false)
+# Set to true to help improve CachiBot by sending anonymous statistics
+# See https://cachibot.ai/telemetry for details on what is collected
+enabled = false
+# install_id = ""  # Auto-generated UUID, do not edit manually
+# Override with environment variable: CACHIBOT_TELEMETRY_DISABLED=1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { TitleBar } from './components/layout/TitleBar'
 import { AuthCallback } from './components/auth/AuthCallback'
 import { LoginPage } from './components/auth/LoginPage'
 import { SetupPage } from './components/auth/SetupPage'
+import { ConsentPage } from './components/auth/ConsentPage'
 import { ProtectedRoute } from './components/auth/ProtectedRoute'
 import { UsersView } from './components/views/UsersView'
 import { useUIStore } from './stores/ui'
@@ -29,6 +30,7 @@ function App() {
       {/* Auth routes (public) */}
       <Route path="/login" element={<LoginPage />} />
       <Route path="/setup" element={<SetupPage />} />
+      <Route path="/consent" element={<ConsentPage />} />
       <Route path="/auth/callback" element={<AuthCallback />} />
 
       {/* Protected routes */}

--- a/frontend/src/api/telemetry.ts
+++ b/frontend/src/api/telemetry.ts
@@ -1,0 +1,93 @@
+/**
+ * Telemetry API Client
+ */
+
+import { useAuthStore } from '../stores/auth'
+import { tryRefreshToken } from './auth'
+
+const API_BASE = '/api'
+
+async function request<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  retry = true
+): Promise<T> {
+  const url = `${API_BASE}${endpoint}`
+  const { accessToken } = useAuthStore.getState()
+
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      ...options.headers,
+    },
+    ...options,
+  })
+
+  if (response.status === 401 && retry) {
+    const newToken = await tryRefreshToken()
+    if (newToken) {
+      return request<T>(endpoint, options, false)
+    }
+  }
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.detail || `Request failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+// Types
+
+export interface TelemetryStatus {
+  enabled: boolean
+  install_id: string
+  last_sent: string
+  terms_accepted: boolean
+  terms_version: string
+  terms_accepted_at: string
+}
+
+export interface TelemetrySettingsUpdate {
+  enabled?: boolean
+  terms_accepted?: boolean
+  terms_version?: string
+}
+
+export interface ConsentRequest {
+  terms_accepted: boolean
+  terms_version: string
+  telemetry_enabled: boolean
+}
+
+// API functions
+
+export async function getTelemetryStatus(): Promise<TelemetryStatus> {
+  return request('/telemetry/status')
+}
+
+export async function getTelemetryPreview(): Promise<Record<string, unknown>> {
+  return request('/telemetry/preview')
+}
+
+export async function updateTelemetrySettings(
+  data: TelemetrySettingsUpdate
+): Promise<TelemetryStatus> {
+  return request('/telemetry/settings', {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function resetTelemetryId(): Promise<{ install_id: string }> {
+  return request('/telemetry/reset-id', { method: 'POST' })
+}
+
+export async function acceptConsent(data: ConsentRequest): Promise<TelemetryStatus> {
+  return request('/telemetry/consent', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}

--- a/frontend/src/components/auth/ConsentPage.tsx
+++ b/frontend/src/components/auth/ConsentPage.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Shield, Loader2, ArrowRight, ChevronDown, ChevronUp, BarChart3, ExternalLink } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAuthStore } from '../../stores/auth'
+import { useTelemetryStore } from '../../stores/telemetry'
+import { acceptConsent } from '../../api/telemetry'
+import { Button } from '../common/Button'
+
+const TERMS_VERSION = '1.0'
+
+export function ConsentPage() {
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuthStore()
+  const { status, refresh } = useTelemetryStore()
+
+  const [termsAccepted, setTermsAccepted] = useState(false)
+  const [telemetryEnabled, setTelemetryEnabled] = useState(false)
+  const [showDetails, setShowDetails] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/login', { replace: true })
+      return
+    }
+
+    refresh().then(() => setLoading(false)).catch(() => setLoading(false))
+  }, [isAuthenticated, navigate, refresh])
+
+  // If terms already accepted, redirect to dashboard
+  useEffect(() => {
+    if (status?.terms_accepted) {
+      navigate('/', { replace: true })
+    }
+  }, [status, navigate])
+
+  const handleContinue = async () => {
+    if (!termsAccepted) {
+      toast.error('Please accept the Terms of Service to continue')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await acceptConsent({
+        terms_accepted: true,
+        terms_version: TERMS_VERSION,
+        telemetry_enabled: telemetryEnabled,
+      })
+      await refresh()
+      toast.success('Welcome to CachiBot!')
+      navigate('/', { replace: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save consent'
+      toast.error(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex-1 min-h-0 flex items-center justify-center bg-zinc-100 dark:bg-zinc-950">
+        <Loader2 className="h-8 w-8 animate-spin text-accent-500" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 min-h-0 flex items-center justify-center bg-zinc-100 dark:bg-zinc-950 px-4">
+      <div className="w-full max-w-lg">
+        {/* Logo */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-accent-500 to-accent-600 mb-4">
+            <Shield className="h-8 w-8 text-white" />
+          </div>
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-white">Welcome to CachiBot</h1>
+          <p className="text-zinc-500 dark:text-zinc-400 mt-1">Just a few things before we get started</p>
+        </div>
+
+        {/* Consent Card */}
+        <div className="bg-white dark:bg-zinc-900 rounded-xl border border-zinc-200 dark:border-zinc-800 p-6 shadow-sm space-y-6">
+          {/* Terms Section */}
+          <div>
+            <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3">Terms of Service</h3>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+              By using CachiBot, you agree to our{' '}
+              <a
+                href="https://cachibot.ai/terms"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-500 hover:text-accent-400 underline inline-flex items-center gap-0.5"
+              >
+                Terms of Service
+                <ExternalLink className="h-3 w-3" />
+              </a>{' '}
+              and{' '}
+              <a
+                href="https://cachibot.ai/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-500 hover:text-accent-400 underline inline-flex items-center gap-0.5"
+              >
+                Privacy Policy
+                <ExternalLink className="h-3 w-3" />
+              </a>
+              .
+            </p>
+
+            <label className="flex items-start gap-3 cursor-pointer group">
+              <input
+                type="checkbox"
+                checked={termsAccepted}
+                onChange={(e) => setTermsAccepted(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-accent-600 focus:ring-accent-500 dark:border-zinc-600 dark:bg-zinc-800"
+              />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300 group-hover:text-zinc-900 dark:group-hover:text-zinc-100">
+                I accept the Terms of Service and Privacy Policy
+              </span>
+            </label>
+          </div>
+
+          {/* Analytics Section */}
+          <div className="border-t border-zinc-200 dark:border-zinc-800 pt-5">
+            <div className="flex items-center gap-2 mb-3">
+              <BarChart3 className="h-4 w-4 text-zinc-500" />
+              <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Anonymous Analytics</h3>
+            </div>
+
+            <label className="flex items-start gap-3 cursor-pointer group mb-3">
+              <input
+                type="checkbox"
+                checked={telemetryEnabled}
+                onChange={(e) => setTelemetryEnabled(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-accent-600 focus:ring-accent-500 dark:border-zinc-600 dark:bg-zinc-800"
+              />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300 group-hover:text-zinc-900 dark:group-hover:text-zinc-100">
+                Help improve CachiBot by sending anonymous usage statistics
+              </span>
+            </label>
+
+            {/* Expandable details */}
+            <button
+              onClick={() => setShowDetails(!showDetails)}
+              className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+            >
+              {showDetails ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              {showDetails ? 'Hide details' : 'What we collect & what we never collect'}
+            </button>
+
+            {showDetails && (
+              <div className="mt-3 space-y-3 text-xs">
+                <div className="rounded-lg border border-green-500/20 bg-green-500/5 p-3">
+                  <p className="font-medium text-green-600 dark:text-green-400 mb-1.5">What we collect:</p>
+                  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+                    <li>- App version, OS type, Python version</li>
+                    <li>- Database type (sqlite/postgresql)</li>
+                    <li>- Aggregate counts: bots, messages, users</li>
+                    <li>- Uptime duration</li>
+                    <li>- A random install ID (resettable)</li>
+                  </ul>
+                </div>
+                <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                  <p className="font-medium text-red-500 dark:text-red-400 mb-1.5">What we NEVER collect:</p>
+                  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+                    <li>- Messages or conversation content</li>
+                    <li>- API keys or passwords</li>
+                    <li>- Email addresses or usernames</li>
+                    <li>- IP addresses (anonymized to 0.0.0.0)</li>
+                    <li>- File paths or workspace content</li>
+                  </ul>
+                </div>
+                <a
+                  href="https://cachibot.ai/telemetry"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-accent-500 hover:text-accent-400"
+                >
+                  Full telemetry disclosure
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* Continue button */}
+          <Button
+            onClick={handleContinue}
+            className="w-full justify-center"
+            disabled={!termsAccepted || submitting}
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Saving...
+              </>
+            ) : (
+              <>
+                Continue
+                <ArrowRight className="h-4 w-4 ml-2" />
+              </>
+            )}
+          </Button>
+        </div>
+
+        {/* Footer */}
+        <p className="text-center text-zinc-500 text-xs mt-6">
+          You can change analytics settings anytime in Settings &gt; Data &amp; Privacy
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/auth/SetupPage.tsx
+++ b/frontend/src/components/auth/SetupPage.tsx
@@ -69,7 +69,7 @@ export function SetupPage() {
       })
       storeLogin(response.user, response.access_token, response.refresh_token)
       toast.success('Admin account created successfully!')
-      navigate('/')
+      navigate('/consent')
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Setup failed'
       toast.error(message)

--- a/frontend/src/stores/telemetry.ts
+++ b/frontend/src/stores/telemetry.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand'
+import type { TelemetryStatus } from '../api/telemetry'
+
+interface TelemetryState {
+  status: TelemetryStatus | null
+  loading: boolean
+
+  setStatus: (status: TelemetryStatus) => void
+  setLoading: (loading: boolean) => void
+  refresh: () => Promise<void>
+}
+
+export const useTelemetryStore = create<TelemetryState>((set) => ({
+  status: null,
+  loading: false,
+
+  setStatus: (status) => set({ status }),
+  setLoading: (loading) => set({ loading }),
+
+  refresh: async () => {
+    set({ loading: true })
+    try {
+      const { getTelemetryStatus } = await import('../api/telemetry')
+      const status = await getTelemetryStatus()
+      set({ status, loading: false })
+    } catch {
+      set({ loading: false })
+    }
+  },
+}))

--- a/src/cachibot/api/routes/__init__.py
+++ b/src/cachibot/api/routes/__init__.py
@@ -10,6 +10,7 @@ from cachibot.api.routes import (
     models,
     plugins,
     providers,
+    telemetry,
     update,
     work,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "models",
     "plugins",
     "providers",
+    "telemetry",
     "update",
     "work",
 ]

--- a/src/cachibot/api/routes/telemetry.py
+++ b/src/cachibot/api/routes/telemetry.py
@@ -1,0 +1,169 @@
+"""Telemetry API endpoints."""
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from cachibot.api.auth import get_current_user
+from cachibot.models.auth import User
+
+router = APIRouter()
+
+
+# ---------- Response / request models ----------
+
+
+class TelemetryStatusResponse(BaseModel):
+    """Current telemetry status."""
+
+    enabled: bool
+    install_id: str
+    last_sent: str
+    terms_accepted: bool
+    terms_version: str
+    terms_accepted_at: str
+
+
+class TelemetrySettingsUpdate(BaseModel):
+    """Update telemetry settings."""
+
+    enabled: bool | None = None
+    terms_accepted: bool | None = None
+    terms_version: str | None = None
+
+
+class ConsentRequest(BaseModel):
+    """First-run consent request."""
+
+    terms_accepted: bool
+    terms_version: str
+    telemetry_enabled: bool = False
+
+
+class ResetIdResponse(BaseModel):
+    """Response after resetting install ID."""
+
+    install_id: str
+
+
+# ---------- Endpoints ----------
+
+
+@router.get("/telemetry/status", response_model=TelemetryStatusResponse)
+async def telemetry_status(
+    user: User = Depends(get_current_user),
+) -> TelemetryStatusResponse:
+    """Get current telemetry status."""
+    from cachibot.config import Config
+
+    config = Config.load()
+
+    # Ensure install_id exists
+    if not config.telemetry.install_id:
+        config.telemetry.install_id = uuid.uuid4().hex
+        config.save_telemetry_config()
+
+    return TelemetryStatusResponse(
+        enabled=config.telemetry.enabled
+        and os.getenv("CACHIBOT_TELEMETRY_DISABLED", "").lower() not in ("1", "true", "yes"),
+        install_id=config.telemetry.install_id,
+        last_sent=config.telemetry.last_sent,
+        terms_accepted=config.telemetry.terms_accepted,
+        terms_version=config.telemetry.terms_version,
+        terms_accepted_at=config.telemetry.terms_accepted_at,
+    )
+
+
+@router.get("/telemetry/preview")
+async def telemetry_preview(
+    user: User = Depends(get_current_user),
+) -> dict:
+    """Preview the exact telemetry payload that would be sent."""
+    from cachibot.telemetry.collector import collect_telemetry
+
+    return collect_telemetry()
+
+
+@router.put("/telemetry/settings", response_model=TelemetryStatusResponse)
+async def update_telemetry_settings(
+    update: TelemetrySettingsUpdate,
+    user: User = Depends(get_current_user),
+) -> TelemetryStatusResponse:
+    """Update telemetry settings."""
+    from cachibot.config import Config
+
+    config = Config.load()
+
+    if update.enabled is not None:
+        config.telemetry.enabled = update.enabled
+    if update.terms_accepted is not None:
+        config.telemetry.terms_accepted = update.terms_accepted
+        if update.terms_accepted:
+            config.telemetry.terms_accepted_at = datetime.now(timezone.utc).isoformat()
+    if update.terms_version is not None:
+        config.telemetry.terms_version = update.terms_version
+
+    # Ensure install_id
+    if not config.telemetry.install_id:
+        config.telemetry.install_id = uuid.uuid4().hex
+
+    config.save_telemetry_config()
+
+    return TelemetryStatusResponse(
+        enabled=config.telemetry.enabled
+        and os.getenv("CACHIBOT_TELEMETRY_DISABLED", "").lower() not in ("1", "true", "yes"),
+        install_id=config.telemetry.install_id,
+        last_sent=config.telemetry.last_sent,
+        terms_accepted=config.telemetry.terms_accepted,
+        terms_version=config.telemetry.terms_version,
+        terms_accepted_at=config.telemetry.terms_accepted_at,
+    )
+
+
+@router.post("/telemetry/reset-id", response_model=ResetIdResponse)
+async def reset_install_id(
+    user: User = Depends(get_current_user),
+) -> ResetIdResponse:
+    """Generate a new anonymous install UUID."""
+    from cachibot.config import Config
+
+    config = Config.load()
+    config.telemetry.install_id = uuid.uuid4().hex
+    config.save_telemetry_config()
+
+    return ResetIdResponse(install_id=config.telemetry.install_id)
+
+
+@router.post("/telemetry/consent", response_model=TelemetryStatusResponse)
+async def accept_consent(
+    req: ConsentRequest,
+    user: User = Depends(get_current_user),
+) -> TelemetryStatusResponse:
+    """Accept terms and optionally opt in to telemetry (first-run flow)."""
+    from cachibot.config import Config
+
+    config = Config.load()
+
+    config.telemetry.terms_accepted = req.terms_accepted
+    config.telemetry.terms_version = req.terms_version
+    config.telemetry.terms_accepted_at = datetime.now(timezone.utc).isoformat()
+    config.telemetry.enabled = req.telemetry_enabled
+
+    # Ensure install_id
+    if not config.telemetry.install_id:
+        config.telemetry.install_id = uuid.uuid4().hex
+
+    config.save_telemetry_config()
+
+    return TelemetryStatusResponse(
+        enabled=config.telemetry.enabled
+        and os.getenv("CACHIBOT_TELEMETRY_DISABLED", "").lower() not in ("1", "true", "yes"),
+        install_id=config.telemetry.install_id,
+        last_sent=config.telemetry.last_sent,
+        terms_accepted=config.telemetry.terms_accepted,
+        terms_version=config.telemetry.terms_version,
+        terms_accepted_at=config.telemetry.terms_accepted_at,
+    )

--- a/src/cachibot/config.py
+++ b/src/cachibot/config.py
@@ -168,6 +168,20 @@ class DatabaseConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """Anonymous telemetry configuration (opt-in, disabled by default)."""
+
+    enabled: bool = False
+    install_id: str = ""  # Generated UUID v4 on first run
+    terms_accepted: bool = False
+    terms_version: str = ""
+    terms_accepted_at: str = ""  # ISO timestamp
+    matomo_url: str = "https://matomo.builditdesign.com/matomo.php"
+    matomo_site_id: str = "7"
+    last_sent: str = ""  # ISO timestamp of last telemetry batch
+
+
+@dataclass
 class Config:
     """
     Main configuration container for Cachibot.
@@ -188,6 +202,7 @@ class Config:
     auth: AuthConfig = field(default_factory=AuthConfig)
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     platform: PlatformConfig = field(default_factory=PlatformConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 
     # Runtime paths
     workspace_path: Path = field(default_factory=Path.cwd)
@@ -310,6 +325,10 @@ class Config:
         if website_url := os.getenv("CACHIBOT_WEBSITE_URL"):
             self.platform.website_url = website_url
 
+        # Telemetry override — CACHIBOT_TELEMETRY_DISABLED=1 force-disables
+        if os.getenv("CACHIBOT_TELEMETRY_DISABLED", "").lower() in ("1", "true", "yes"):
+            self.telemetry.enabled = False
+
     def _load_from_file(self, path: Path) -> None:
         """Load configuration from a TOML file."""
 
@@ -407,6 +426,97 @@ class Config:
                 self.database.pool_recycle = db_data["pool_recycle"]
             if "echo" in db_data:
                 self.database.echo = db_data["echo"]
+
+        if telemetry_data := data.get("telemetry"):
+            if "enabled" in telemetry_data:
+                self.telemetry.enabled = telemetry_data["enabled"]
+            if "install_id" in telemetry_data:
+                self.telemetry.install_id = telemetry_data["install_id"]
+            if "terms_accepted" in telemetry_data:
+                self.telemetry.terms_accepted = telemetry_data["terms_accepted"]
+            if "terms_version" in telemetry_data:
+                self.telemetry.terms_version = telemetry_data["terms_version"]
+            if "terms_accepted_at" in telemetry_data:
+                self.telemetry.terms_accepted_at = telemetry_data["terms_accepted_at"]
+            if "matomo_url" in telemetry_data:
+                self.telemetry.matomo_url = telemetry_data["matomo_url"]
+            if "matomo_site_id" in telemetry_data:
+                self.telemetry.matomo_site_id = telemetry_data["matomo_site_id"]
+            if "last_sent" in telemetry_data:
+                self.telemetry.last_sent = telemetry_data["last_sent"]
+
+    def save_telemetry_config(self) -> None:
+        """Persist telemetry settings to the user config file (~/.cachibot.toml).
+
+        Uses a simple read-modify-write approach: loads the existing file,
+        updates just the [telemetry] section, and writes it back. If the file
+        doesn't exist yet it is created with only the telemetry section.
+        """
+        user_config = Path.home() / ".cachibot.toml"
+
+        try:
+            # Try to import tomli_w for writing TOML
+            import tomli_w
+        except ImportError:
+            # Fallback: write a minimal TOML snippet manually
+            self._save_telemetry_manual(user_config)
+            return
+
+        data: dict[str, Any] = {}
+        if user_config.exists() and tomllib is not None:
+            try:
+                with open(user_config, "rb") as f:
+                    data = tomllib.load(f)
+            except Exception:
+                pass
+
+        data["telemetry"] = {
+            "enabled": self.telemetry.enabled,
+            "install_id": self.telemetry.install_id,
+            "terms_accepted": self.telemetry.terms_accepted,
+            "terms_version": self.telemetry.terms_version,
+            "terms_accepted_at": self.telemetry.terms_accepted_at,
+            "last_sent": self.telemetry.last_sent,
+        }
+
+        try:
+            with open(user_config, "wb") as f:
+                tomli_w.dump(data, f)
+        except Exception as exc:
+            logger.debug("Failed to write telemetry config: %s", exc)
+
+    def _save_telemetry_manual(self, path: Path) -> None:
+        """Write telemetry config without tomli_w (plain-text TOML append)."""
+        import re
+
+        t = self.telemetry
+        section = (
+            "\n[telemetry]\n"
+            f'enabled = {"true" if t.enabled else "false"}\n'
+            f'install_id = "{t.install_id}"\n'
+            f'terms_accepted = {"true" if t.terms_accepted else "false"}\n'
+            f'terms_version = "{t.terms_version}"\n'
+            f'terms_accepted_at = "{t.terms_accepted_at}"\n'
+            f'last_sent = "{t.last_sent}"\n'
+        )
+
+        try:
+            if path.exists():
+                content = path.read_text(encoding="utf-8")
+                # Remove existing [telemetry] section if present
+                content = re.sub(
+                    r"\n?\[telemetry\][^\[]*",
+                    "",
+                    content,
+                    flags=re.DOTALL,
+                )
+                content = content.rstrip() + "\n" + section
+            else:
+                content = section.lstrip()
+
+            path.write_text(content, encoding="utf-8")
+        except Exception as exc:
+            logger.debug("Failed to write telemetry config (manual): %s", exc)
 
     def is_path_allowed(self, path: Path | str) -> bool:
         """

--- a/src/cachibot/config.py
+++ b/src/cachibot/config.py
@@ -492,9 +492,9 @@ class Config:
         t = self.telemetry
         section = (
             "\n[telemetry]\n"
-            f'enabled = {"true" if t.enabled else "false"}\n'
+            f"enabled = {'true' if t.enabled else 'false'}\n"
             f'install_id = "{t.install_id}"\n'
-            f'terms_accepted = {"true" if t.terms_accepted else "false"}\n'
+            f"terms_accepted = {'true' if t.terms_accepted else 'false'}\n"
             f'terms_version = "{t.terms_version}"\n'
             f'terms_accepted_at = "{t.terms_accepted_at}"\n'
             f'last_sent = "{t.last_sent}"\n'

--- a/src/cachibot/telemetry/__init__.py
+++ b/src/cachibot/telemetry/__init__.py
@@ -1,0 +1,6 @@
+"""Anonymous telemetry for CachiBot (opt-in, disabled by default)."""
+
+from cachibot.telemetry.collector import collect_telemetry
+from cachibot.telemetry.sender import send_telemetry
+
+__all__ = ["collect_telemetry", "send_telemetry"]

--- a/src/cachibot/telemetry/collector.py
+++ b/src/cachibot/telemetry/collector.py
@@ -45,7 +45,9 @@ def collect_telemetry() -> dict:
         "app_version": __version__,
         "os_type": platform.system().lower(),
         "os_version": platform.release(),
-        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "python_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        ),
         "db_type": db_type,
         "uptime_seconds": uptime_seconds,
         "collected_at": datetime.now(timezone.utc).isoformat(),

--- a/src/cachibot/telemetry/collector.py
+++ b/src/cachibot/telemetry/collector.py
@@ -1,0 +1,116 @@
+"""Collect anonymous telemetry metrics.
+
+NEVER collects: messages, API keys, passwords, emails, IPs, file paths,
+or conversation content. Only aggregate counts and system metadata.
+"""
+
+import logging
+import platform
+import sys
+import time
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+# Server start time (set on import)
+_start_time = time.monotonic()
+
+
+def collect_telemetry() -> dict:
+    """Collect anonymous telemetry payload.
+
+    Returns a dict with system metadata and aggregate usage counts.
+    All data is anonymous — no PII, no message content, no keys.
+    """
+    from cachibot import __version__
+    from cachibot.config import Config
+
+    config = Config.load()
+
+    # Determine database type from config
+    db_url = config.database.url
+    if db_url:
+        if "postgresql" in db_url or "postgres" in db_url:
+            db_type = "postgresql"
+        elif "mysql" in db_url:
+            db_type = "mysql"
+        else:
+            db_type = "other"
+    else:
+        db_type = "sqlite"
+
+    uptime_seconds = int(time.monotonic() - _start_time)
+
+    payload = {
+        "app_version": __version__,
+        "os_type": platform.system().lower(),
+        "os_version": platform.release(),
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "db_type": db_type,
+        "uptime_seconds": uptime_seconds,
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # Aggregate counts from database (best-effort, never fail)
+    try:
+        import asyncio
+
+        counts = asyncio.get_event_loop().run_until_complete(_collect_db_counts())
+        payload.update(counts)
+    except Exception:
+        # If we can't get DB counts (no running loop, etc.), that's fine
+        try:
+            import asyncio
+
+            counts = asyncio.run(_collect_db_counts())
+            payload.update(counts)
+        except Exception:
+            logger.debug("Could not collect DB counts for telemetry")
+
+    return payload
+
+
+async def _collect_db_counts() -> dict:
+    """Collect aggregate counts from the database."""
+    counts: dict = {}
+    try:
+        from cachibot.storage.db import get_session
+
+        async with get_session() as session:
+            from sqlalchemy import text
+
+            # Total bots
+            result = await session.execute(text("SELECT COUNT(*) FROM bots"))
+            row = result.scalar()
+            counts["bot_count"] = row or 0
+
+            # Total messages (aggregate only)
+            try:
+                result = await session.execute(text("SELECT COUNT(*) FROM messages"))
+                row = result.scalar()
+                counts["message_count"] = row or 0
+            except Exception:
+                counts["message_count"] = 0
+
+            # Total users
+            try:
+                result = await session.execute(text("SELECT COUNT(*) FROM users"))
+                row = result.scalar()
+                counts["user_count"] = row or 0
+            except Exception:
+                counts["user_count"] = 0
+
+            # Active connections count
+            try:
+                result = await session.execute(
+                    text("SELECT COUNT(*) FROM connections WHERE status = 'connected'")
+                )
+                row = result.scalar()
+                counts["active_connections"] = row or 0
+            except Exception:
+                counts["active_connections"] = 0
+
+    except Exception:
+        logger.debug("Could not query database for telemetry counts")
+
+    return counts

--- a/src/cachibot/telemetry/scheduler.py
+++ b/src/cachibot/telemetry/scheduler.py
@@ -1,0 +1,93 @@
+"""Background telemetry scheduler.
+
+Runs as an asyncio task during server lifespan. Checks every hour whether
+it's time to send telemetry (>24h since last send). Non-blocking, all
+errors silently caught.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+# Check interval: every hour
+_CHECK_INTERVAL_SECONDS = 3600
+# Send interval: every 24 hours
+_SEND_INTERVAL_SECONDS = 86400
+
+_task: asyncio.Task | None = None
+
+
+async def start_telemetry_scheduler() -> None:
+    """Start the background telemetry scheduler task."""
+    global _task
+    if _task is not None:
+        return
+
+    _task = asyncio.create_task(_scheduler_loop())
+    logger.debug("Telemetry scheduler started")
+
+
+async def stop_telemetry_scheduler() -> None:
+    """Stop the background telemetry scheduler task."""
+    global _task
+    if _task is not None:
+        _task.cancel()
+        try:
+            await _task
+        except asyncio.CancelledError:
+            pass
+        _task = None
+        logger.debug("Telemetry scheduler stopped")
+
+
+async def _scheduler_loop() -> None:
+    """Main scheduler loop — runs until cancelled."""
+    # Initial send on startup (if eligible)
+    await _maybe_send()
+
+    while True:
+        try:
+            await asyncio.sleep(_CHECK_INTERVAL_SECONDS)
+            await _maybe_send()
+        except asyncio.CancelledError:
+            break
+        except Exception as exc:
+            logger.debug("Telemetry scheduler error (silent): %s", exc)
+
+
+async def _maybe_send() -> None:
+    """Send telemetry if enabled and enough time has elapsed."""
+    try:
+        # Respect env var
+        if os.getenv("CACHIBOT_TELEMETRY_DISABLED", "").lower() in ("1", "true", "yes"):
+            return
+
+        from cachibot.config import Config
+
+        config = Config.load()
+
+        if not config.telemetry.enabled:
+            return
+
+        # Check if enough time has passed since last send
+        if config.telemetry.last_sent:
+            try:
+                last_sent = datetime.fromisoformat(config.telemetry.last_sent)
+                elapsed = (datetime.now(timezone.utc) - last_sent).total_seconds()
+                if elapsed < _SEND_INTERVAL_SECONDS:
+                    return
+            except (ValueError, TypeError):
+                pass  # Invalid timestamp — send anyway
+
+        # Collect and send
+        from cachibot.telemetry.collector import collect_telemetry
+        from cachibot.telemetry.sender import send_telemetry
+
+        payload = collect_telemetry()
+        await send_telemetry(payload)
+
+    except Exception as exc:
+        logger.debug("Telemetry _maybe_send error (silent): %s", exc)

--- a/src/cachibot/telemetry/sender.py
+++ b/src/cachibot/telemetry/sender.py
@@ -53,7 +53,7 @@ async def send_telemetry(payload: dict) -> bool:
             "send_image": "0",
             "_id": visitor_id,
             "cip": "0.0.0.0",  # Anonymize IP completely
-            "url": f"app://cachibot/telemetry",
+            "url": "app://cachibot/telemetry",
             "action_name": "Telemetry Report",
             # Custom dimensions for app metadata
             "dimension1": payload.get("os_type", ""),

--- a/src/cachibot/telemetry/sender.py
+++ b/src/cachibot/telemetry/sender.py
@@ -1,0 +1,100 @@
+"""Send telemetry to Matomo via HTTP Tracking API.
+
+All network calls are wrapped in try/except — telemetry must NEVER
+break the application. Failures are logged at DEBUG and silently ignored.
+"""
+
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+logger = logging.getLogger(__name__)
+
+
+async def send_telemetry(payload: dict) -> bool:
+    """Format and send telemetry payload to Matomo.
+
+    Uses Matomo's HTTP Tracking API with bulk tracking format.
+    Returns True if sent successfully, False otherwise.
+    Always silent on failure — never raises.
+    """
+    try:
+        from cachibot.config import Config
+
+        config = Config.load()
+
+        # Respect env var override
+        if os.getenv("CACHIBOT_TELEMETRY_DISABLED", "").lower() in ("1", "true", "yes"):
+            logger.debug("Telemetry disabled via environment variable")
+            return False
+
+        if not config.telemetry.enabled:
+            logger.debug("Telemetry not enabled")
+            return False
+
+        # Ensure we have an install ID
+        if not config.telemetry.install_id:
+            config.telemetry.install_id = uuid.uuid4().hex
+            config.save_telemetry_config()
+
+        install_id = config.telemetry.install_id
+        matomo_url = config.telemetry.matomo_url
+        site_id = config.telemetry.matomo_site_id
+
+        # Build Matomo tracking request parameters
+        # Use first 16 hex chars of install_id as visitor ID
+        visitor_id = install_id[:16]
+
+        params = {
+            "idsite": site_id,
+            "rec": "1",
+            "send_image": "0",
+            "_id": visitor_id,
+            "cip": "0.0.0.0",  # Anonymize IP completely
+            "url": f"app://cachibot/telemetry",
+            "action_name": "Telemetry Report",
+            # Custom dimensions for app metadata
+            "dimension1": payload.get("os_type", ""),
+            "dimension2": payload.get("python_version", ""),
+            "dimension3": payload.get("app_version", ""),
+            "dimension4": payload.get("db_type", ""),
+            # Custom variables for aggregate counts
+            "cvar": _build_custom_vars(payload),
+        }
+
+        url = f"{matomo_url}?{urlencode(params)}"
+
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+
+        # Update last_sent timestamp
+        config.telemetry.last_sent = datetime.now(timezone.utc).isoformat()
+        config.save_telemetry_config()
+
+        logger.debug("Telemetry sent successfully")
+        return True
+
+    except Exception as exc:
+        logger.debug("Telemetry send failed (silent): %s", exc)
+        return False
+
+
+def _build_custom_vars(payload: dict) -> str:
+    """Build Matomo custom variables JSON string from payload counts."""
+    import json
+
+    cvars = {}
+    slot = 1
+    for key in ("bot_count", "message_count", "user_count", "active_connections", "uptime_seconds"):
+        if key in payload:
+            cvars[str(slot)] = [key, str(payload[key])]
+            slot += 1
+            if slot > 5:
+                break  # Matomo supports max 5 custom variables
+
+    return json.dumps(cvars) if cvars else "{}"


### PR DESCRIPTION
Introduce an opt-in anonymous telemetry subsystem and first-run consent UI.

- Backend: add telemetry API routes (status, preview, settings, reset-id, consent), telemetry package (collector, sender, scheduler), and register router in the API server. Start/stop telemetry scheduler during app lifespan. Add telemetry config dataclass and persistence helpers (save_telemetry_config/_save_telemetry_manual) and load telemetry settings from file/env. Add CLI telemetry commands (status/enable/disable/show).
- Frontend: add ConsentPage, telemetry API client, telemetry zustand store, wire consent route and redirect from SetupPage, protect routes to require consent, and add telemetry controls (toggle, preview, reset id) in App Settings.
- Config: update example toml with telemetry section and respect CACHIBOT_TELEMETRY_DISABLED env override.

Telemetry is designed to be non-blocking and silent on failure, never collecting PII or message content. This change enables administrators to opt in/out and inspect what would be sent.