### PR TITLE
Add Electron updater, custom colors & UI tweaks

### DIFF
--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -18,4 +18,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('window:maximized', handler);
     return () => ipcRenderer.removeListener('window:maximized', handler);
   },
+  // Update management
+  checkForUpdate: () => ipcRenderer.invoke('update:check'),
+  downloadUpdate: () => ipcRenderer.invoke('update:download'),
+  installUpdate: () => ipcRenderer.send('update:install'),
+  onUpdateAvailable: (callback) => {
+    const handler = (_event, info) => callback(info);
+    ipcRenderer.on('update:available', handler);
+    return () => ipcRenderer.removeListener('update:available', handler);
+  },
+  onUpdateProgress: (callback) => {
+    const handler = (_event, progress) => callback(progress);
+    ipcRenderer.on('update:download-progress', handler);
+    return () => ipcRenderer.removeListener('update:download-progress', handler);
+  },
+  // Cache management
+  clearCache: () => ipcRenderer.invoke('cache:clear'),
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -70,6 +70,7 @@ export interface HealthInfo {
   build: string
   python: string
   platform: string
+  desktop: boolean
 }
 
 export async function checkHealth(): Promise<HealthInfo> {

--- a/frontend/src/components/common/UpdateBanner.tsx
+++ b/frontend/src/components/common/UpdateBanner.tsx
@@ -4,6 +4,9 @@ import { useUpdateStore } from '../../stores/update'
 export function UpdateBanner() {
   const { showBanner, checkResult, dismissBanner, openDialog } = useUpdateStore()
 
+  // In Electron, updates are handled via the native updater in Settings
+  if (window.electronAPI?.isDesktop) return null
+
   if (!showBanner || !checkResult) return null
 
   const latestVersion = checkResult.latest_stable || checkResult.latest_prerelease

--- a/frontend/src/components/dialogs/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/frontend/src/components/dialogs/OnboardingWizard/steps/PreferencesStep.tsx
@@ -1,5 +1,5 @@
-import { Sun, Moon, Monitor } from 'lucide-react'
-import { useUIStore, type Theme, type AccentColor, accentColors } from '../../../../stores/ui'
+import { Sun, Moon, Monitor, Plus } from 'lucide-react'
+import { useUIStore, type Theme, type PresetColor, accentColors, generatePalette } from '../../../../stores/ui'
 import { cn } from '../../../../lib/utils'
 
 const themeOptions: { value: Theme; label: string; icon: typeof Sun }[] = [
@@ -8,11 +8,12 @@ const themeOptions: { value: Theme; label: string; icon: typeof Sun }[] = [
   { value: 'system', label: 'System', icon: Monitor },
 ]
 
-const colorOptions = Object.entries(accentColors) as [AccentColor, (typeof accentColors)[AccentColor]][]
+const colorOptions = Object.entries(accentColors) as [PresetColor, (typeof accentColors)[PresetColor]][]
 
 export function PreferencesStep() {
-  const { theme, setTheme, accentColor, setAccentColor, showThinking, setShowThinking, showCost, setShowCost } =
+  const { theme, setTheme, accentColor, setAccentColor, customHex, setCustomHex, showThinking, setShowThinking, showCost, setShowCost } =
     useUIStore()
+  const customPalette = generatePalette(customHex)
 
   return (
     <div className="space-y-6">
@@ -48,27 +49,41 @@ export function PreferencesStep() {
       {/* Accent Color */}
       <div className="space-y-2">
         <label className="block text-sm font-medium text-zinc-700 dark:text-[var(--color-text-primary)]">Accent Color</label>
-        <div className="grid grid-cols-4 gap-2">
-          {colorOptions.map(([value, { name, palette }]) => (
+        <div className="settings-color-grid">
+          {colorOptions.map(([value, { palette }]) => (
             <button
               key={value}
               onClick={() => setAccentColor(value)}
               className={cn(
-                'flex items-center gap-2 rounded-lg border p-3 transition-all',
-                accentColor === value
-                  ? 'border-2 ring-1 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900'
-                  : 'border-zinc-300 hover:border-zinc-400 dark:border-[var(--color-border-secondary)] dark:hover:border-[var(--color-border-secondary)]'
+                'settings-color-circle',
+                accentColor === value && 'settings-color-circle--active'
               )}
               style={{
-                borderColor: accentColor === value ? palette[500] : undefined,
-                // @ts-expect-error - Tailwind CSS variable
-                '--tw-ring-color': accentColor === value ? palette[500] : undefined,
+                backgroundColor: palette[500],
+                boxShadow: accentColor === value ? `0 0 0 2px var(--color-bg-primary), 0 0 0 4px ${palette[500]}` : undefined,
               }}
-            >
-              <div className="h-5 w-5 rounded-full" style={{ backgroundColor: palette[500] }} />
-              <span className="text-sm text-zinc-700 dark:text-[var(--color-text-primary)]">{name}</span>
-            </button>
+              title={value.charAt(0).toUpperCase() + value.slice(1)}
+            />
           ))}
+          <label
+            className={cn(
+              'settings-color-circle settings-color-circle--custom',
+              accentColor === 'custom' && 'settings-color-circle--active'
+            )}
+            style={{
+              backgroundColor: customPalette[500],
+              boxShadow: accentColor === 'custom' ? `0 0 0 2px var(--color-bg-primary), 0 0 0 4px ${customPalette[500]}` : undefined,
+            }}
+            title="Custom"
+          >
+            <Plus className="settings-color-circle__icon" />
+            <input
+              type="color"
+              value={customHex}
+              onChange={(e) => setCustomHex(e.target.value)}
+              className="settings-color-circle__input"
+            />
+          </label>
         </div>
       </div>
 

--- a/frontend/src/components/dialogs/UpdateDialog.tsx
+++ b/frontend/src/components/dialogs/UpdateDialog.tsx
@@ -19,6 +19,9 @@ export function UpdateDialog() {
     setOptIntoBeta,
   } = useUpdateStore()
 
+  // In Electron, updates are handled via the native updater in Settings
+  if (window.electronAPI?.isDesktop) return null
+
   if (!showDialog || !checkResult) return null
 
   const latestVersion = checkResult.latest_stable || checkResult.latest_prerelease

--- a/frontend/src/components/settings/BotEnvironmentPanel.tsx
+++ b/frontend/src/components/settings/BotEnvironmentPanel.tsx
@@ -185,9 +185,9 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <Loader2 className="h-5 w-5 animate-spin text-[var(--color-text-secondary)]" />
-        <span className="ml-2 text-sm text-[var(--color-text-secondary)]">Loading environment...</span>
+      <div className="bot-env-loading">
+        <Loader2 className="h-5 w-5 animate-spin" />
+        <span>Loading environment...</span>
       </div>
     )
   }
@@ -195,19 +195,15 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
   return (
     <div className="space-y-6">
       {/* Error banner */}
-      {error && (
-        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-400">
-          {error}
-        </div>
-      )}
+      {error && <div className="bot-env-error">{error}</div>}
 
       {/* Info banner */}
-      <div className="rounded-lg border border-zinc-300 dark:border-[var(--color-border-secondary)] bg-zinc-100 dark:bg-[var(--card-bg)] p-4">
-        <div className="flex items-start gap-3">
-          <Shield className="mt-0.5 h-5 w-5 flex-shrink-0 text-cachi-500" />
+      <div className="bot-env-info">
+        <div className="bot-env-info__body">
+          <Shield className="h-5 w-5 bot-env-info__icon" />
           <div>
-            <p className="text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]">Per-Bot Environment</p>
-            <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+            <p className="bot-env-info__title">Per-Bot Environment</p>
+            <p className="bot-env-info__text">
               Override API keys and settings for this bot. Custom keys take priority over
               global settings. Keys are encrypted at rest and never returned in plain text.
             </p>
@@ -219,14 +215,14 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
       <div>
         <button
           onClick={() => setProviderKeysOpen(!providerKeysOpen)}
-          className="flex w-full items-center gap-2 text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]"
+          className="bot-env-section-toggle"
         >
           {providerKeysOpen ? (
-            <ChevronDown className="h-4 w-4 text-[var(--color-text-secondary)]" />
+            <ChevronDown className="bot-env-section-toggle__chevron" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-[var(--color-text-secondary)]" />
+            <ChevronRight className="bot-env-section-toggle__chevron" />
           )}
-          <Key className="h-4 w-4 text-[var(--color-text-secondary)] dark:text-[var(--color-text-secondary)]" />
+          <Key className="bot-env-section-toggle__icon" />
           Provider Keys
         </button>
 
@@ -238,89 +234,67 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
               const hasBotOverride = botVars.some((v) => v.key === provider.key)
 
               return (
-                <div
-                  key={provider.key}
-                  className="rounded-lg border border-zinc-200 dark:border-[var(--color-border-primary)] p-3"
-                >
+                <div key={provider.key} className="bot-env-card">
                   {isEditing ? (
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]">
-                          {provider.label}
-                        </span>
-                        <span className="text-xs text-[var(--color-text-tertiary)]">{provider.key}</span>
+                        <span className="bot-env-card__label">{provider.label}</span>
+                        <span className="bot-env-card__env-key">{provider.key}</span>
                       </div>
-                      <div className="relative">
+                      <div className="bot-env-edit__input-wrap">
                         <input
                           type={showValue ? 'text' : 'password'}
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
                           placeholder={`Enter ${provider.type === 'endpoint' ? 'endpoint URL' : 'API key'}...`}
-                          className="w-full rounded border border-zinc-300 dark:border-[var(--color-border-secondary)] bg-white dark:bg-[var(--color-bg-secondary)] px-3 py-1.5 pr-10 text-sm text-zinc-900 dark:text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)]"
+                          className="bot-env-edit__input"
                           autoFocus
                         />
                         <button
                           onClick={() => setShowValue(!showValue)}
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-tertiary)] dark:hover:text-[var(--color-text-primary)]"
+                          className="bot-env-edit__toggle-vis"
                         >
-                          {showValue ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
+                          {showValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                         </button>
                       </div>
-                      <div className="flex gap-2">
+                      <div className="bot-env-edit__actions">
                         <button
                           onClick={() => handleSetKey(provider.key, editValue)}
                           disabled={!editValue.trim() || saving}
-                          className="flex items-center gap-1 rounded bg-cachi-600 px-2 py-1 text-xs text-white hover:bg-cachi-500 disabled:opacity-50"
+                          className="bot-env-edit__save-btn"
                         >
-                          {saving ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                          ) : (
-                            <Check className="h-3 w-3" />
-                          )}
+                          {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
                           Save
                         </button>
-                        <button
-                          onClick={cancelEdit}
-                          className="rounded bg-zinc-200 dark:bg-[var(--color-hover-bg)] px-2 py-1 text-xs text-zinc-700 dark:text-[var(--color-text-primary)] hover:bg-zinc-300 dark:hover:bg-[var(--color-active-bg)]"
-                        >
+                        <button onClick={cancelEdit} className="bot-env-edit__cancel-btn">
                           <X className="h-3 w-3" />
                         </button>
                       </div>
                     </div>
                   ) : (
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]">
-                              {provider.label}
-                            </span>
-                            <SourceBadge source={status.source} />
-                          </div>
-                          <div className="mt-0.5 text-xs text-[var(--color-text-secondary)]">
-                            {status.configured
-                              ? status.maskedValue || 'Configured'
-                              : 'Not set'}
-                          </div>
+                    <div className="bot-env-card__row">
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="bot-env-card__label">{provider.label}</span>
+                          <SourceBadge source={status.source} />
+                        </div>
+                        <div className="bot-env-card__masked">
+                          {status.configured ? status.maskedValue || 'Configured' : 'Not set'}
                         </div>
                       </div>
-                      <div className="flex items-center gap-1">
+                      <div className="bot-env-card__actions">
                         {hasBotOverride ? (
                           <>
                             <button
                               onClick={() => startEdit(provider.key)}
-                              className="rounded p-1.5 text-[var(--color-text-secondary)] hover:bg-zinc-100 dark:hover:bg-[var(--color-hover-bg)] hover:text-[var(--color-text-tertiary)] dark:hover:text-[var(--color-text-primary)]"
+                              className="bot-env-icon-btn"
                               title="Edit override"
                             >
                               <Pencil className="h-3.5 w-3.5" />
                             </button>
                             <button
                               onClick={() => handleDeleteKey(provider.key)}
-                              className="rounded p-1.5 text-[var(--color-text-secondary)] hover:bg-zinc-100 dark:hover:bg-[var(--color-hover-bg)] hover:text-red-400"
+                              className="bot-env-icon-btn bot-env-icon-btn--danger"
                               title="Remove override (fall back to inherited)"
                             >
                               <Trash2 className="h-3.5 w-3.5" />
@@ -329,7 +303,7 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
                         ) : (
                           <button
                             onClick={() => startEdit(provider.key)}
-                            className="rounded px-2 py-1 text-xs text-[var(--color-text-secondary)] dark:text-[var(--color-text-secondary)] hover:bg-zinc-100 dark:hover:bg-[var(--color-hover-bg)] hover:text-zinc-900 dark:hover:text-[var(--color-text-primary)]"
+                            className="bot-env-override-btn"
                           >
                             Override
                           </button>
@@ -348,18 +322,16 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
       <div>
         <button
           onClick={() => setCustomKeysOpen(!customKeysOpen)}
-          className="flex w-full items-center gap-2 text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]"
+          className="bot-env-section-toggle"
         >
           {customKeysOpen ? (
-            <ChevronDown className="h-4 w-4 text-[var(--color-text-secondary)]" />
+            <ChevronDown className="bot-env-section-toggle__chevron" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-[var(--color-text-secondary)]" />
+            <ChevronRight className="bot-env-section-toggle__chevron" />
           )}
           Custom Variables
           {customBotVars.length > 0 && (
-            <span className="rounded-full bg-zinc-200 dark:bg-[var(--color-hover-bg)] px-2 py-0.5 text-xs text-[var(--color-text-secondary)] dark:text-[var(--color-text-secondary)]">
-              {customBotVars.length}
-            </span>
+            <span className="bot-env-section-toggle__count">{customBotVars.length}</span>
           )}
         </button>
 
@@ -369,63 +341,60 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
               const isEditing = editingKey === v.key
 
               return (
-                <div
-                  key={v.key}
-                  className="rounded-lg border border-zinc-200 dark:border-[var(--color-border-primary)] p-3"
-                >
+                <div key={v.key} className="bot-env-card">
                   {isEditing ? (
                     <div className="space-y-2">
-                      <span className="text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]">{v.key}</span>
-                      <div className="relative">
+                      <span className="bot-env-card__label">{v.key}</span>
+                      <div className="bot-env-edit__input-wrap">
                         <input
                           type={showValue ? 'text' : 'password'}
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
                           placeholder="Enter new value..."
-                          className="w-full rounded border border-zinc-300 dark:border-[var(--color-border-secondary)] bg-white dark:bg-[var(--color-bg-secondary)] px-3 py-1.5 pr-10 text-sm text-zinc-900 dark:text-[var(--color-text-primary)]"
+                          className="bot-env-edit__input"
                           autoFocus
                         />
                         <button
                           onClick={() => setShowValue(!showValue)}
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-tertiary)] dark:hover:text-[var(--color-text-primary)]"
+                          className="bot-env-edit__toggle-vis"
                         >
                           {showValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                         </button>
                       </div>
-                      <div className="flex gap-2">
+                      <div className="bot-env-edit__actions">
                         <button
                           onClick={() => handleSetKey(v.key, editValue)}
                           disabled={!editValue.trim() || saving}
-                          className="flex items-center gap-1 rounded bg-cachi-600 px-2 py-1 text-xs text-white hover:bg-cachi-500 disabled:opacity-50"
+                          className="bot-env-edit__save-btn"
                         >
                           {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
                           Save
                         </button>
-                        <button onClick={cancelEdit} className="rounded bg-zinc-200 dark:bg-[var(--color-hover-bg)] px-2 py-1 text-xs text-zinc-700 dark:text-[var(--color-text-primary)] hover:bg-zinc-300 dark:hover:bg-[var(--color-active-bg)]">
+                        <button onClick={cancelEdit} className="bot-env-edit__cancel-btn">
                           <X className="h-3 w-3" />
                         </button>
                       </div>
                     </div>
                   ) : (
-                    <div className="flex items-center justify-between">
+                    <div className="bot-env-card__row">
                       <div>
                         <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-zinc-800 dark:text-[var(--color-text-primary)]">{v.key}</span>
+                          <span className="bot-env-card__label">{v.key}</span>
                           <SourceBadge source="bot" />
                         </div>
-                        <div className="mt-0.5 text-xs text-[var(--color-text-secondary)]">{v.masked_value}</div>
+                        <div className="bot-env-card__masked">{v.masked_value}</div>
                       </div>
-                      <div className="flex items-center gap-1">
+                      <div className="bot-env-card__actions">
                         <button
                           onClick={() => startEdit(v.key)}
-                          className="rounded p-1.5 text-[var(--color-text-secondary)] hover:bg-zinc-100 dark:hover:bg-[var(--color-hover-bg)] hover:text-[var(--color-text-tertiary)] dark:hover:text-[var(--color-text-primary)]"
+                          className="bot-env-icon-btn"
                           title="Edit"
                         >
                           <Pencil className="h-3.5 w-3.5" />
                         </button>
                         <button
                           onClick={() => handleDeleteKey(v.key)}
-                          className="rounded p-1.5 text-[var(--color-text-secondary)] hover:bg-zinc-100 dark:hover:bg-[var(--color-hover-bg)] hover:text-red-400"
+                          className="bot-env-icon-btn bot-env-icon-btn--danger"
                           title="Delete"
                         >
                           <Trash2 className="h-3.5 w-3.5" />
@@ -439,13 +408,13 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
 
             {/* Add custom key form */}
             {addingCustom ? (
-              <div className="space-y-2 rounded-lg border border-zinc-300 dark:border-[var(--color-border-secondary)] bg-zinc-100 dark:bg-[var(--card-bg)] p-3">
+              <div className="bot-env-add-form space-y-2">
                 <input
                   type="text"
                   value={customKeyName}
                   onChange={(e) => setCustomKeyName(e.target.value.toUpperCase())}
                   placeholder="VARIABLE_NAME"
-                  className="w-full rounded border border-zinc-300 dark:border-[var(--color-border-secondary)] bg-white dark:bg-[var(--color-bg-secondary)] px-3 py-1.5 text-sm text-zinc-900 dark:text-[var(--color-text-primary)] font-mono placeholder:text-[var(--color-text-tertiary)]"
+                  className="bot-env-add-form__input--mono"
                   autoFocus
                 />
                 <input
@@ -453,30 +422,27 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
                   value={customKeyValue}
                   onChange={(e) => setCustomKeyValue(e.target.value)}
                   placeholder="Value..."
-                  className="w-full rounded border border-zinc-300 dark:border-[var(--color-border-secondary)] bg-white dark:bg-[var(--color-bg-secondary)] px-3 py-1.5 text-sm text-zinc-900 dark:text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)]"
+                  className="bot-env-add-form__input"
                 />
-                <div className="flex gap-2">
+                <div className="bot-env-edit__actions">
                   <button
                     onClick={handleAddCustomKey}
                     disabled={!customKeyName.trim() || !customKeyValue.trim() || saving}
-                    className="flex items-center gap-1 rounded bg-cachi-600 px-3 py-1 text-xs text-white hover:bg-cachi-500 disabled:opacity-50"
+                    className="bot-env-edit__save-btn"
                   >
                     {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}
                     Add
                   </button>
                   <button
                     onClick={() => { setAddingCustom(false); setCustomKeyName(''); setCustomKeyValue('') }}
-                    className="rounded bg-zinc-200 dark:bg-[var(--color-hover-bg)] px-3 py-1 text-xs text-zinc-700 dark:text-[var(--color-text-primary)] hover:bg-zinc-300 dark:hover:bg-[var(--color-active-bg)]"
+                    className="bot-env-edit__cancel-btn"
                   >
                     Cancel
                   </button>
                 </div>
               </div>
             ) : (
-              <button
-                onClick={() => setAddingCustom(true)}
-                className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-zinc-300 dark:border-[var(--color-border-secondary)] p-2.5 text-sm text-[var(--color-text-secondary)] hover:border-zinc-400 dark:hover:border-[var(--color-border-secondary)] hover:text-[var(--color-text-tertiary)] dark:hover:text-[var(--color-text-secondary)]"
-              >
+              <button onClick={() => setAddingCustom(true)} className="bot-env-add-btn">
                 <Plus className="h-4 w-4" />
                 Add Custom Variable
               </button>
@@ -487,27 +453,27 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
 
       {/* Danger Zone */}
       {(botVars.length > 0) && (
-        <div className="border-t border-zinc-200 dark:border-[var(--color-border-primary)] pt-6">
-          <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4">
-            <h3 className="text-sm font-semibold text-red-400">Danger Zone</h3>
-            <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+        <div className="bot-env-danger">
+          <div className="bot-env-danger__panel">
+            <h3 className="bot-env-danger__title">Danger Zone</h3>
+            <p className="bot-env-danger__text">
               Remove all custom environment overrides for this bot. The bot will revert
               to using inherited global and platform-level settings.
             </p>
             {showResetConfirm ? (
               <div className="mt-3 flex items-center gap-2">
-                <span className="text-xs text-red-400">Are you sure?</span>
+                <span className="bot-env-danger__confirm-text">Are you sure?</span>
                 <button
                   onClick={handleResetAll}
                   disabled={resetting}
-                  className="flex items-center gap-1 rounded bg-red-600 px-3 py-1 text-xs text-white hover:bg-red-500 disabled:opacity-50"
+                  className="bot-env-danger__confirm-btn"
                 >
                   {resetting ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
                   Confirm Reset
                 </button>
                 <button
                   onClick={() => setShowResetConfirm(false)}
-                  className="rounded px-3 py-1 text-xs text-[var(--color-text-secondary)] dark:text-[var(--color-text-secondary)] hover:text-zinc-900 dark:hover:text-[var(--color-text-primary)]"
+                  className="bot-env-danger__cancel-btn"
                 >
                   Cancel
                 </button>
@@ -515,7 +481,7 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
             ) : (
               <button
                 onClick={() => setShowResetConfirm(true)}
-                className="mt-3 flex items-center gap-2 rounded-lg border border-red-500/50 px-3 py-1.5 text-xs text-red-400 hover:bg-red-500/10"
+                className="bot-env-danger__reset-btn mt-3"
               >
                 <RotateCcw className="h-3.5 w-3.5" />
                 Reset All to Defaults
@@ -533,36 +499,23 @@ export function BotEnvironmentPanel({ botId }: BotEnvironmentPanelProps) {
 // ---------------------------------------------------------------------------
 
 function SourceBadge({ source }: { source: string }) {
-  switch (source) {
-    case 'bot':
-      return (
-        <span className="rounded-full bg-green-500/20 px-2 py-0.5 text-[10px] font-medium text-green-400">
-          Custom
-        </span>
-      )
-    case 'platform':
-      return (
-        <span className="rounded-full bg-blue-500/20 px-2 py-0.5 text-[10px] font-medium text-blue-400">
-          Platform
-        </span>
-      )
-    case 'global':
-      return (
-        <span className="rounded-full bg-zinc-200 dark:bg-zinc-600/30 px-2 py-0.5 text-[10px] font-medium text-[var(--color-text-secondary)] dark:text-[var(--color-text-secondary)]">
-          Global
-        </span>
-      )
-    case 'none':
-      return (
-        <span className="rounded-full bg-zinc-200 dark:bg-[var(--color-bg-secondary)] px-2 py-0.5 text-[10px] font-medium text-[var(--color-text-tertiary)]">
-          Not Set
-        </span>
-      )
-    default:
-      return (
-        <span className="rounded-full bg-zinc-200 dark:bg-[var(--color-bg-inset)] px-2 py-0.5 text-[10px] font-medium text-[var(--color-text-secondary)]">
-          {source}
-        </span>
-      )
+  const classMap: Record<string, string> = {
+    bot: 'bot-env-badge--bot',
+    platform: 'bot-env-badge--platform',
+    global: 'bot-env-badge--global',
+    none: 'bot-env-badge--none',
   }
+
+  const labelMap: Record<string, string> = {
+    bot: 'Custom',
+    platform: 'Platform',
+    global: 'Global',
+    none: 'Not Set',
+  }
+
+  return (
+    <span className={`bot-env-badge ${classMap[source] || 'bot-env-badge--default'}`}>
+      {labelMap[source] || source}
+    </span>
+  )
 }

--- a/frontend/src/components/views/ChatView.tsx
+++ b/frontend/src/components/views/ChatView.tsx
@@ -21,7 +21,7 @@ import {
   Volume2,
 } from 'lucide-react'
 import { useChatStore, useBotStore } from '../../stores/bots'
-import { useUIStore, accentColors } from '../../stores/ui'
+import { useUIStore, accentColors, generatePalette } from '../../stores/ui'
 import { useCreationFlowStore } from '../../stores/creation-flow'
 import { useModelsStore } from '../../stores/models'
 import { BotIconRenderer } from '../common/BotIconRenderer'
@@ -1106,8 +1106,10 @@ function MessageBubble({ message, botIcon, botColor, onReply, chatId }: MessageB
   const [copied, setCopied] = useState(false)
   const [showInfo, setShowInfo] = useState(false)
   const [showToolCalls, setShowToolCalls] = useState(false)
-  const { accentColor } = useUIStore()
-  const userColor = accentColors[accentColor].palette[600]
+  const { accentColor, customHex } = useUIStore()
+  const userColor = accentColor === 'custom'
+    ? generatePalette(customHex)[600]
+    : accentColors[accentColor].palette[600]
   const getMessageById = useChatStore((s) => s.getMessageById)
 
   // Resolve reply-to message

--- a/frontend/src/components/views/SettingsView.tsx
+++ b/frontend/src/components/views/SettingsView.tsx
@@ -20,6 +20,7 @@ import {
   AudioLines,
   Layers,
   Mic,
+  Plus,
 } from 'lucide-react'
 import { useBotStore, DEFAULT_BOT_SETTINGS, getEffectiveModels } from '../../stores/bots'
 import { usePlatformToolsStore } from '../../stores/platform-tools'
@@ -47,6 +48,8 @@ import type { Bot as BotType, BotModels, SkillDefinition } from '../../types'
 const COLOR_OPTIONS = [
   '#22c55e', '#3b82f6', '#8b5cf6', '#ec4899',
   '#f59e0b', '#ef4444', '#06b6d4', '#84cc16',
+  '#14b8a6', '#6366f1', '#f43f5e', '#eab308',
+  '#a855f7',
 ]
 
 export function SettingsView() {
@@ -553,20 +556,40 @@ function GeneralSection({ form, setForm, onReset }: GeneralSectionProps) {
           </div>
           <div>
             <label className="settings-form__label--icon">Color</label>
-            <div className="flex flex-wrap gap-2">
+            <div className="settings-color-grid">
               {COLOR_OPTIONS.map((color) => (
                 <button
                   key={color}
                   onClick={() => setForm({ ...form, color })}
                   className={cn(
-                    'settings-color-btn',
-                    form.color === color
-                      ? 'settings-color-btn--active'
-                      : 'settings-color-btn--inactive'
+                    'settings-color-circle',
+                    form.color === color && 'settings-color-circle--active'
                   )}
-                  style={{ backgroundColor: color }}
+                  style={{
+                    backgroundColor: color,
+                    boxShadow: form.color === color ? `0 0 0 2px var(--color-bg-primary), 0 0 0 4px ${color}` : undefined,
+                  }}
                 />
               ))}
+              <label
+                className={cn(
+                  'settings-color-circle settings-color-circle--custom',
+                  form.color && !COLOR_OPTIONS.includes(form.color) && 'settings-color-circle--active'
+                )}
+                style={{
+                  backgroundColor: form.color && !COLOR_OPTIONS.includes(form.color) ? form.color : 'var(--color-active-bg)',
+                  boxShadow: form.color && !COLOR_OPTIONS.includes(form.color) ? `0 0 0 2px var(--color-bg-primary), 0 0 0 4px ${form.color}` : undefined,
+                }}
+                title="Custom color"
+              >
+                <Plus className="settings-color-circle__icon" />
+                <input
+                  type="color"
+                  value={form.color}
+                  onChange={(e) => setForm({ ...form, color: e.target.value })}
+                  className="settings-color-circle__input"
+                />
+              </label>
             </div>
           </div>
         </div>

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -2,14 +2,15 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 export type Theme = 'light' | 'dark' | 'system'
-export type AccentColor = 'green' | 'pink' | 'blue' | 'purple' | 'orange' | 'red' | 'cyan' | 'yellow'
+export type PresetColor = 'green' | 'pink' | 'blue' | 'purple' | 'orange' | 'red' | 'cyan' | 'yellow' | 'teal' | 'indigo' | 'rose' | 'amber' | 'lime'
+export type AccentColor = PresetColor | 'custom'
 export type SettingsSection = 'general' | 'knowledge' | 'skills' | 'connections' | 'environment' | 'danger'
 export type WorkSection = 'overview' | 'active' | 'completed' | 'history'
 export type ScheduleSection = 'all' | 'enabled' | 'disabled' | 'create'
 export type AutomationSection = 'all' | 'functions' | 'scripts' | 'schedules'
 
 // Accent color palettes (Tailwind-style)
-export const accentColors: Record<AccentColor, { name: string; palette: Record<string, string> }> = {
+export const accentColors: Record<PresetColor, { name: string; palette: Record<string, string> }> = {
   green: {
     name: 'Green',
     palette: {
@@ -66,11 +67,97 @@ export const accentColors: Record<AccentColor, { name: string; palette: Record<s
       500: '#eab308', 600: '#ca8a04', 700: '#a16207', 800: '#854d0e', 900: '#713f12', 950: '#422006',
     },
   },
+  teal: {
+    name: 'Teal',
+    palette: {
+      50: '#f0fdfa', 100: '#ccfbf1', 200: '#99f6e4', 300: '#5eead4', 400: '#2dd4bf',
+      500: '#14b8a6', 600: '#0d9488', 700: '#0f766e', 800: '#115e59', 900: '#134e4a', 950: '#042f2e',
+    },
+  },
+  indigo: {
+    name: 'Indigo',
+    palette: {
+      50: '#eef2ff', 100: '#e0e7ff', 200: '#c7d2fe', 300: '#a5b4fc', 400: '#818cf8',
+      500: '#6366f1', 600: '#4f46e5', 700: '#4338ca', 800: '#3730a3', 900: '#312e81', 950: '#1e1b4b',
+    },
+  },
+  rose: {
+    name: 'Rose',
+    palette: {
+      50: '#fff1f2', 100: '#ffe4e6', 200: '#fecdd3', 300: '#fda4af', 400: '#fb7185',
+      500: '#f43f5e', 600: '#e11d48', 700: '#be123c', 800: '#9f1239', 900: '#881337', 950: '#4c0519',
+    },
+  },
+  amber: {
+    name: 'Amber',
+    palette: {
+      50: '#fffbeb', 100: '#fef3c7', 200: '#fde68a', 300: '#fcd34d', 400: '#fbbf24',
+      500: '#f59e0b', 600: '#d97706', 700: '#b45309', 800: '#92400e', 900: '#78350f', 950: '#451a03',
+    },
+  },
+  lime: {
+    name: 'Lime',
+    palette: {
+      50: '#f7fee7', 100: '#ecfccb', 200: '#d9f99d', 300: '#bef264', 400: '#a3e635',
+      500: '#84cc16', 600: '#65a30d', 700: '#4d7c0f', 800: '#3f6212', 900: '#365314', 950: '#1a2e05',
+    },
+  },
+}
+
+// Generate a full palette from a single hex color
+function hexToHsl(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255
+  const g = parseInt(hex.slice(3, 5), 16) / 255
+  const b = parseInt(hex.slice(5, 7), 16) / 255
+  const max = Math.max(r, g, b), min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l]
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max - min)
+  let h = 0
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+  else if (max === g) h = ((b - r) / d + 2) / 6
+  else h = ((r - g) / d + 4) / 6
+  return [h * 360, s * 100, l * 100]
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100; l /= 100
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)
+    return Math.round(255 * Math.max(0, Math.min(1, color))).toString(16).padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
+}
+
+export function generatePalette(hex: string): Record<string, string> {
+  const [h, s] = hexToHsl(hex)
+  const shades: [string, number, number][] = [
+    ['50', Math.max(s - 30, 5), 97],
+    ['100', Math.max(s - 20, 10), 93],
+    ['200', Math.max(s - 10, 15), 86],
+    ['300', s, 76],
+    ['400', s, 64],
+    ['500', s, 50],
+    ['600', s, 42],
+    ['700', Math.min(s + 5, 100), 34],
+    ['800', Math.min(s + 10, 100), 26],
+    ['900', Math.min(s + 10, 100), 20],
+    ['950', Math.min(s + 15, 100), 12],
+  ]
+  const palette: Record<string, string> = {}
+  for (const [key, sat, light] of shades) {
+    palette[key] = hslToHex(h, sat, light)
+  }
+  return palette
 }
 
 interface UIState {
   theme: Theme
   accentColor: AccentColor
+  customHex: string
   sidebarCollapsed: boolean
   mobileMenuOpen: boolean
   settingsOpen: boolean
@@ -87,6 +174,7 @@ interface UIState {
   // Actions
   setTheme: (theme: Theme) => void
   setAccentColor: (color: AccentColor) => void
+  setCustomHex: (hex: string) => void
   toggleTheme: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
   toggleSidebar: () => void
@@ -109,6 +197,7 @@ export const useUIStore = create<UIState>()(
     (set) => ({
       theme: 'system',
       accentColor: 'green',
+      customHex: '#8b5cf6',
       sidebarCollapsed: false,
       mobileMenuOpen: false,
       settingsOpen: false,
@@ -124,6 +213,7 @@ export const useUIStore = create<UIState>()(
 
       setTheme: (theme) => set({ theme }),
       setAccentColor: (accentColor) => set({ accentColor }),
+      setCustomHex: (customHex) => set({ customHex, accentColor: 'custom' }),
       toggleTheme: () =>
         set((state) => ({
           theme: state.theme === 'light' ? 'dark' : 'light',
@@ -150,6 +240,7 @@ export const useUIStore = create<UIState>()(
       partialize: (state) => ({
         theme: state.theme,
         accentColor: state.accentColor,
+        customHex: state.customHex,
         sidebarCollapsed: state.sidebarCollapsed,
         showThinking: state.showThinking,
         showCost: state.showCost,

--- a/frontend/src/styles/components/app-settings.less
+++ b/frontend/src/styles/components/app-settings.less
@@ -341,30 +341,50 @@
 // Accent color picker
 // -----------------------------------------------------------------------------
 
-.settings-color-btn {
+.settings-color-grid {
   display: flex;
-  align-items: center;
-  gap: @sp-2;
-  border-radius: @radius-lg;
-  padding: @sp-3;
-  border: 1px solid var(--color-border-secondary);
-  background: none;
+  flex-wrap: wrap;
+  gap: @sp-3;
+}
+
+.settings-color-circle {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: @radius-full;
+  border: none;
   cursor: pointer;
   .transition-all();
 
   &:hover {
-    border-color: var(--color-text-tertiary);
+    transform: scale(1.15);
   }
 
-  &__swatch {
-    height: 1.25rem;
-    width: 1.25rem;
-    border-radius: @radius-full;
+  &--active {
+    transform: scale(1.15);
   }
 
-  &__name {
-    font-size: @text-sm;
-    color: var(--color-text-primary);
+  &--custom {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+
+  &__icon {
+    width: 0.875rem;
+    height: 0.875rem;
+    color: white;
+    pointer-events: none;
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.3));
+  }
+
+  &__input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
   }
 }
 

--- a/frontend/src/styles/components/bot-env.less
+++ b/frontend/src/styles/components/bot-env.less
@@ -1,0 +1,400 @@
+// =============================================================================
+// Bot Environment Panel — components/bot-env.less
+// Per-bot environment variables: provider keys, custom vars, badges
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Loading state
+// -----------------------------------------------------------------------------
+
+.bot-env-loading {
+  .flex-center();
+  padding: @sp-8 0;
+  gap: @sp-2;
+  font-size: @text-sm;
+  color: var(--color-text-secondary);
+}
+
+// -----------------------------------------------------------------------------
+// Error banner
+// -----------------------------------------------------------------------------
+
+.bot-env-error {
+  border-radius: @radius-lg;
+  border: 1px solid rgba(@red-500, 0.5);
+  background: rgba(@red-500, 0.1);
+  padding: @sp-3;
+  font-size: @text-sm;
+  color: @red-400;
+}
+
+// -----------------------------------------------------------------------------
+// Info banner
+// -----------------------------------------------------------------------------
+
+.bot-env-info {
+  border-radius: @radius-lg;
+  border: 1px solid var(--color-border-secondary);
+  background: var(--card-bg);
+  padding: @sp-4;
+
+  &__body {
+    display: flex;
+    align-items: flex-start;
+    gap: @sp-3;
+  }
+
+  &__icon {
+    margin-top: 2px;
+    flex-shrink: 0;
+    color: var(--accent-500);
+  }
+
+  &__title {
+    font-size: @text-sm;
+    font-weight: @font-medium;
+    color: var(--color-text-primary);
+  }
+
+  &__text {
+    margin-top: @sp-1;
+    font-size: @text-xs;
+    color: var(--color-text-secondary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Section toggle (Provider Keys / Custom Variables)
+// -----------------------------------------------------------------------------
+
+.bot-env-section-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: @sp-2;
+  font-size: @text-sm;
+  font-weight: @font-medium;
+  color: var(--color-text-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+
+  &__chevron {
+    height: 1rem;
+    width: 1rem;
+    color: var(--color-text-secondary);
+  }
+
+  &__icon {
+    height: 1rem;
+    width: 1rem;
+    color: var(--color-text-secondary);
+  }
+
+  &__count {
+    border-radius: @radius-full;
+    background: var(--color-hover-bg);
+    padding: @sp-0\.5 @sp-2;
+    font-size: @text-xs;
+    font-weight: @font-medium;
+    color: var(--color-text-secondary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Provider key card
+// -----------------------------------------------------------------------------
+
+.bot-env-card {
+  border-radius: @radius-lg;
+  border: 1px solid var(--color-border-primary);
+  padding: @sp-3;
+
+  &__row {
+    .flex-between();
+  }
+
+  &__label {
+    font-size: @text-sm;
+    font-weight: @font-medium;
+    color: var(--color-text-primary);
+  }
+
+  &__env-key {
+    font-size: @text-xs;
+    color: var(--color-text-tertiary);
+  }
+
+  &__masked {
+    margin-top: 2px;
+    font-size: @text-xs;
+    color: var(--color-text-secondary);
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: @sp-1;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Action buttons (edit, delete, override)
+// -----------------------------------------------------------------------------
+
+.bot-env-icon-btn {
+  border-radius: @radius-sm;
+  padding: 6px;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  .transition-colors();
+
+  &:hover {
+    background: var(--color-hover-bg);
+    color: var(--color-text-primary);
+  }
+
+  &--danger:hover {
+    color: @red-400;
+  }
+}
+
+.bot-env-override-btn {
+  border-radius: @radius-sm;
+  padding: @sp-1 @sp-2;
+  font-size: @text-xs;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  .transition-colors();
+
+  &:hover {
+    background: var(--color-hover-bg);
+    color: var(--color-text-primary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Edit form (inline key editing)
+// -----------------------------------------------------------------------------
+
+.bot-env-edit {
+  &__input-wrap {
+    position: relative;
+  }
+
+  &__input {
+    .input-base();
+    padding: @sp-1\.5 @sp-10 @sp-1\.5 @sp-3;
+    font-size: @text-sm;
+  }
+
+  &__toggle-vis {
+    position: absolute;
+    right: @sp-2;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-text-secondary);
+    background: none;
+    border: none;
+    cursor: pointer;
+    .transition-colors();
+
+    &:hover {
+      color: var(--color-text-primary);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: @sp-2;
+  }
+
+  &__save-btn {
+    .button-base();
+    .button-size(xs);
+    background: var(--accent-600);
+    color: white;
+
+    &:hover {
+      background: var(--accent-500);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__cancel-btn {
+    .button-base();
+    .button-size(xs);
+    background: var(--color-hover-bg);
+    color: var(--color-text-primary);
+
+    &:hover {
+      background: var(--color-active-bg);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Add custom key form
+// -----------------------------------------------------------------------------
+
+.bot-env-add-form {
+  border-radius: @radius-lg;
+  border: 1px solid var(--color-border-secondary);
+  background: var(--card-bg);
+  padding: @sp-3;
+
+  &__input {
+    .input-base();
+    padding: @sp-1\.5 @sp-3;
+    font-size: @text-sm;
+  }
+
+  &__input--mono {
+    .input-base();
+    padding: @sp-1\.5 @sp-3;
+    font-size: @text-sm;
+    font-family: @font-mono;
+  }
+}
+
+.bot-env-add-btn {
+  .flex-center();
+  width: 100%;
+  gap: @sp-2;
+  border-radius: @radius-lg;
+  border: 1px dashed var(--color-border-secondary);
+  padding: @sp-2\.5;
+  font-size: @text-sm;
+  color: var(--color-text-secondary);
+  background: none;
+  cursor: pointer;
+  .transition-colors();
+
+  &:hover {
+    border-color: var(--color-text-tertiary);
+    color: var(--color-text-primary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Source badge
+// -----------------------------------------------------------------------------
+
+.bot-env-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: @radius-full;
+  padding: @sp-0\.5 @sp-2;
+  font-size: 10px;
+  font-weight: @font-medium;
+
+  &--bot {
+    background: rgba(@green-500, 0.2);
+    color: @green-400;
+  }
+
+  &--platform {
+    background: rgba(@blue-500, 0.2);
+    color: @blue-400;
+  }
+
+  &--global {
+    background: var(--color-hover-bg);
+    color: var(--color-text-secondary);
+  }
+
+  &--none {
+    background: var(--color-bg-secondary);
+    color: var(--color-text-tertiary);
+  }
+
+  &--default {
+    background: var(--color-bg-inset, var(--color-hover-bg));
+    color: var(--color-text-secondary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Danger zone
+// -----------------------------------------------------------------------------
+
+.bot-env-danger {
+  border-top: 1px solid var(--color-border-primary);
+  padding-top: @sp-6;
+
+  &__panel {
+    border-radius: @radius-lg;
+    border: 1px solid rgba(@red-500, 0.3);
+    background: rgba(@red-500, 0.05);
+    padding: @sp-4;
+  }
+
+  &__title {
+    font-size: @text-sm;
+    font-weight: @font-semibold;
+    color: @red-400;
+  }
+
+  &__text {
+    margin-top: @sp-1;
+    font-size: @text-xs;
+    color: var(--color-text-secondary);
+  }
+
+  &__confirm-text {
+    font-size: @text-xs;
+    color: @red-400;
+  }
+
+  &__reset-btn {
+    .button-base();
+    .button-size(xs);
+    border: 1px solid rgba(@red-500, 0.5);
+    border-radius: @radius-lg;
+    color: @red-400;
+    background: none;
+
+    &:hover {
+      background: rgba(@red-500, 0.1);
+    }
+  }
+
+  &__confirm-btn {
+    .button-base();
+    .button-size(xs);
+    background: @red-600;
+    color: white;
+
+    &:hover {
+      background: @red-500;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__cancel-btn {
+    border-radius: @radius-sm;
+    padding: @sp-1 @sp-3;
+    font-size: @text-xs;
+    color: var(--color-text-secondary);
+    background: none;
+    border: none;
+    cursor: pointer;
+    .transition-colors();
+
+    &:hover {
+      color: var(--color-text-primary);
+    }
+  }
+}

--- a/frontend/src/styles/components/dashboard.less
+++ b/frontend/src/styles/components/dashboard.less
@@ -39,31 +39,39 @@
 // -----------------------------------------------------------------------------
 
 .dashboard-time-range {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: @sp-1;
   border-radius: @radius-lg;
-  background: var(--color-active-bg);
-  padding: @sp-1;
+  border: 1px solid var(--color-border-primary);
+  background: var(--color-bg-secondary);
+  padding: 3px;
+  gap: 2px;
 
   &__btn {
     border-radius: @radius-md;
     padding: @sp-1\.5 @sp-3;
-    font-size: @text-sm;
+    font-size: @text-xs;
     font-weight: @font-medium;
     background: none;
     border: none;
     cursor: pointer;
-    .transition-colors();
-    color: var(--color-text-secondary);
+    .transition-all();
+    color: var(--color-text-tertiary);
 
     &:hover {
       color: var(--color-text-primary);
+      background: var(--color-hover-bg);
     }
 
     &--active {
       background: var(--accent-600);
       color: white;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+
+      &:hover {
+        background: var(--accent-500);
+        color: white;
+      }
     }
   }
 }

--- a/frontend/src/styles/components/settings-view.less
+++ b/frontend/src/styles/components/settings-view.less
@@ -358,30 +358,8 @@
   }
 }
 
-// -----------------------------------------------------------------------------
-// Color Picker
-// -----------------------------------------------------------------------------
-
-.settings-color-btn {
-  height: @height-sm;
-  width: @height-sm;
-  border-radius: @radius-lg;
-  .transition-all();
-  cursor: pointer;
-
-  &--active {
-    border: 2px solid white;
-    transform: scale(1.1);
-  }
-
-  &--inactive {
-    border: 2px solid transparent;
-
-    &:hover {
-      transform: scale(1.05);
-    }
-  }
-}
+// Color Picker — uses shared .settings-color-grid / .settings-color-circle
+// defined in app-settings.less
 
 // -----------------------------------------------------------------------------
 // Skills Section

--- a/frontend/src/styles/index.less
+++ b/frontend/src/styles/index.less
@@ -48,6 +48,7 @@
 // 6b. View-specific components
 @import './components/app-settings.less';
 @import './components/settings-view.less';
+@import './components/bot-env.less';
 @import './components/dashboard.less';
 @import './components/schedules.less';
 @import './components/tools-view.less';

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,6 +5,19 @@ declare module '*.css' {
   export default content
 }
 
+interface UpdateCheckResult {
+  available: boolean
+  version?: string
+  releaseNotes?: string | { version: string; note: string }[] | null
+}
+
+interface UpdateDownloadProgress {
+  bytesPerSecond: number
+  percent: number
+  transferred: number
+  total: number
+}
+
 interface ElectronAPI {
   platform: string
   isDesktop: boolean
@@ -18,6 +31,14 @@ interface ElectronAPI {
   windowClose: () => void
   windowIsMaximized: () => Promise<boolean>
   onMaximizedChange: (callback: (maximized: boolean) => void) => () => void
+  // Update management
+  checkForUpdate: () => Promise<UpdateCheckResult>
+  downloadUpdate: () => Promise<{ success: boolean }>
+  installUpdate: () => void
+  onUpdateAvailable: (callback: (info: UpdateCheckResult) => void) => () => void
+  onUpdateProgress: (callback: (progress: UpdateDownloadProgress) => void) => () => void
+  // Cache management
+  clearCache: () => Promise<{ success: boolean; error?: string }>
 }
 
 interface Window {

--- a/src/cachibot/api/routes/health.py
+++ b/src/cachibot/api/routes/health.py
@@ -1,5 +1,6 @@
 """Health check endpoint."""
 
+import os
 import platform
 import sys
 
@@ -28,6 +29,7 @@ class HealthResponse(BaseModel):
     build: str = _detect_build()
     python: str = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     platform: str = platform.system().lower()
+    desktop: bool = os.environ.get("CACHIBOT_DESKTOP", "").lower() == "true"
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/src/cachibot/api/server.py
+++ b/src/cachibot/api/server.py
@@ -254,15 +254,24 @@ def create_app(
         @app.get("/")
         async def serve_spa():
             """Serve the frontend SPA."""
-            return FileResponse(FRONTEND_DIST / "index.html")
+            return FileResponse(
+                FRONTEND_DIST / "index.html",
+                headers={"Cache-Control": "no-cache, must-revalidate"},
+            )
 
         @app.get("/{path:path}")
         async def serve_spa_routes(path: str):
             """Serve static files or fallback to index.html for SPA routing."""
             file_path = FRONTEND_DIST / path
             if file_path.exists() and file_path.is_file():
-                return FileResponse(file_path)
-            return FileResponse(FRONTEND_DIST / "index.html")
+                headers = {}
+                if path.startswith("assets/"):
+                    headers["Cache-Control"] = "public, max-age=31536000, immutable"
+                return FileResponse(file_path, headers=headers)
+            return FileResponse(
+                FRONTEND_DIST / "index.html",
+                headers={"Cache-Control": "no-cache, must-revalidate"},
+            )
     else:
 
         @app.get("/")


### PR DESCRIPTION
Integrate native Electron auto-updater and cache handling, expose update/cache IPC to renderer, and add desktop-aware UI. Main process: track app version, clear Chromium cache on version changes, wire up autoUpdater events (available, downloaded, progress, error), periodic update checks, and IPC handlers for check/download/install and cache clearing. Preload: expose update and cache APIs to window.electronAPI and push update events. Frontend: detect desktop mode and hide web-based update banner/dialog; implement an Electron-specific Updates section in AppSettingsView with check/download/install flows, progress and release-notes rendering; wire clear-cache button to call native cache clearing when available. Add custom accent color support across the UI (store types, customHex, generatePalette usage) and update PreferencesStep, MainLayout, AppSettingsView, ChatView, SettingsView to render and apply preset/custom palettes. Refactor BotEnvironmentPanel markup and badges to use new CSS class names and add bot-env styles (new stylesheet). Update client health types to include a desktop flag and adjust backend health/server to support desktop detection. Miscellaneous UI/UX polish and telemetry logs for updater events.