### PR TITLE
Add tray support and improve backend shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev]
   pull_request:
-    branches: [dev, main]
+    branches: [dev]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -41,6 +41,11 @@
         "from": "../build/backend/",
         "to": "backend",
         "filter": ["**/*"]
+      },
+      {
+        "from": "../assets/",
+        "to": "assets",
+        "filter": ["icon.ico", "icon.png"]
       }
     ],
     "win": {

--- a/src/cachibot/__init__.py
+++ b/src/cachibot/__init__.py
@@ -24,7 +24,7 @@ def _get_version() -> str:
 
     candidates = [
         Path(__file__).parent / "VERSION",  # bundled in package
-        Path(__file__).parent.parent.parent.parent / "VERSION",  # repo root (editable)
+        Path(__file__).parent.parent.parent / "VERSION",  # repo root (editable install)
     ]
     # PyInstaller frozen binary: VERSION is bundled at _MEIPASS/cachibot/VERSION
     if getattr(sys, "_MEIPASS", None):


### PR DESCRIPTION
Add system tray support to the Electron app: import Tray, Menu and nativeImage, add createTray() to build a tray icon and context menu (Show, Check for Updates, Restart, Quit), load/reserve icon assets, and show/focus the main window on click. Improve backend shutdown on Windows by invoking taskkill to terminate the whole process tree (with a fallback to kill) and ensure backendProcess is cleared. Update packaging to include icon assets (icon.ico, icon.png) so the tray icon is bundled. Also fix the Python VERSION lookup path in src/cachibot/__init__.py for editable installs by adjusting the parent path traversal.