### PR TITLE
Expose app version; add clear-cache restart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,6 +227,7 @@ jobs:
           --hidden-import=cachibot.services
           --hidden-import=cachibot.storage
           --add-data "src/cachibot${{ matrix.data_sep }}cachibot"
+          --add-data "VERSION${{ matrix.data_sep }}cachibot"
           --add-data "frontend/dist${{ matrix.data_sep }}cachibot/frontend_dist"
           desktop/pyinstaller-server.py
 

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -3,6 +3,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   isDesktop: true,
+  appVersion: ipcRenderer.sendSync('app:getVersion'),
   versions: {
     electron: process.versions.electron,
     node: process.versions.node,

--- a/frontend/src/components/views/AppSettingsView.tsx
+++ b/frontend/src/components/views/AppSettingsView.tsx
@@ -282,7 +282,7 @@ function GeneralSettings({
           <div className="settings-info-row">
             <span className="settings-info-row__label">Version</span>
             <span className="settings-info-row__value">
-              {healthInfo?.version ?? '...'}
+              {window.electronAPI?.appVersion ?? healthInfo?.version ?? '...'}
             </span>
           </div>
           <div className="settings-info-row">
@@ -552,7 +552,7 @@ function PipUpdatesSection({ healthInfo }: { healthInfo: HealthInfo | null }) {
     checkForUpdate()
   }, [checkForUpdate])
 
-  const currentVersion = checkResult?.current_version || healthInfo?.version || '...'
+  const currentVersion = window.electronAPI?.appVersion || checkResult?.current_version || healthInfo?.version || '...'
   const latestStable = checkResult?.latest_stable
   const latestPrerelease = checkResult?.latest_prerelease
   const hasUpdate = checkResult?.update_available || checkResult?.prerelease_available

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -21,6 +21,7 @@ interface UpdateDownloadProgress {
 interface ElectronAPI {
   platform: string
   isDesktop: boolean
+  appVersion: string
   versions: {
     electron: string
     node: string


### PR DESCRIPTION
Expose the desktop app version to the renderer and use it in the UI, add a Clear Cache & Restart tray action, and include the VERSION marker in packaged builds.

- desktop: show version in tray tooltip and add a "Clear Cache & Restart" menu item that clears session cache/storage, removes the Code Cache dir and the VERSION file, stops the backend, and relaunches the app. Added ipcMain handler 'app:getVersion'.
- preload: expose appVersion via ipcRenderer.sendSync so the renderer can read the app version synchronously.
- frontend: use window.electronAPI?.appVersion when displaying the app version and for update checks; update ElectronAPI type to include appVersion.
- CI (publish.yml): include the VERSION file in pyinstaller packaging so the build contains the version marker used by the app.