### PR TITLE
Standardize UTC datetimes, fix usage attribution, and expand Azure provider support

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: create-pr
-description: Generate a pull request title and description from the current branch's commits. Writes a warm, personality-driven summary paragraph and detailed technical bullets.
+description: Generate a pull request title and description from the current branch's commits. Produces a concise summary, optional feature highlights, and collapsible technical details.
 ---
 
 # Create PR Description
 
-Generate a pull request title and description with personality — the kind that makes someone smile while learning exactly what changed.
+Generate a pull request title and description that's scannable, informative, and has just enough personality to feel human.
 
 ## Instructions
 
@@ -26,23 +26,53 @@ git diff main..HEAD
 
 If the full diff is too large, diff individual areas (backend routes, frontend, storage, etc.) in batches. You must understand **what the code actually does**, not just which files were touched.
 
-### 2. Write `pr.md`
+### 2. Write the PR file
 
-Write a `pr.md` file at the repository root with this structure:
+Write the file to `.pr/YYYY-MM-DD.md` (using today's date). Create the `.pr/` directory if it doesn't exist. If a file for today's date already exists, append a counter: `YYYY-MM-DD-2.md`, `YYYY-MM-DD-3.md`, etc.
 
-```markdown
+The structure depends on whether the PR introduces user-facing features or is purely internal (refactors, bug fixes, infra).
+
+#### When the PR has user-facing features:
+
+~~~markdown
 # <Title>
 
-## Summary
+<2-3 sentence summary>
 
-<A single flowing paragraph — warm, conversational, technically precise. Tell the story of what this PR does and why it matters. Weave in the key changes naturally. Think "engineer telling a friend about their week" not "changelog". Name actual classes, functions, and patterns but keep it readable as prose.>
+### Highlights
 
-## Technical details
+- Highlight 1
+- Highlight 2
+- ...
+
+<details>
+<summary>Technical changes</summary>
 
 - Detail 1
 - Detail 2
 - ...
-```
+
+</details>
+~~~
+
+#### When the PR is purely internal (no user-facing features):
+
+~~~markdown
+# <Title>
+
+<2-3 sentence summary>
+
+<details>
+<summary>Technical changes</summary>
+
+- Detail 1
+- Detail 2
+- ...
+
+</details>
+~~~
+
+Omit the Highlights section entirely for internal-only PRs — don't force it.
 
 ### Style Rules
 
@@ -50,23 +80,28 @@ Write a `pr.md` file at the repository root with this structure:
 - Imperative mood, start with a verb (Add, Fix, Refactor, etc.)
 - Summarize the entire PR scope — not just one commit
 
-#### Summary paragraph
-- **One flowing paragraph**, not bullets. This is a narrative.
-- **Start with personality.** Open with something that makes the reader smile — a cheerful greeting, a silly observation, a lighthearted joke, a warm "hope your day is going well" vibe. Not forced, just human. Examples of the energy (don't copy these literally, make up your own each time):
+#### Summary
+- **2-3 sentences max.** This is the elevator pitch, not the full story.
+- **Open with a touch of personality.** One line that makes the reader smile — a wry observation, a lighthearted remark, a playful metaphor. Not forced, just human. Examples of the energy (don't copy these literally, invent your own each time):
   - "This one's mostly about cleaning house."
   - "Turns out the type checker was right to complain."
   - A playful metaphor about what the code was doing wrong
   - A wry observation about the state of things before this PR
-- **Stay technically precise inside the warmth.** Name the actual things — "`get_or_create_chat` had a race condition", not "fixed some database stuff". The personality is in *how* you describe the real changes, not in being vague.
-- **Cover all major change areas** in the paragraph — security, architecture, bug fixes, refactors, new features. Weave them into the story naturally.
-- **Keep it engaging end-to-end.** Don't front-load all the fun and then go dry. Sprinkle personality throughout — a vivid verb here, a dry quip there, an analogy that makes a complex change click.
+- **Then say what the PR does at a high level.** Name the main change areas (new feature, refactor target, bug fixed) but don't enumerate every file. The personality is in *how* you describe the changes, not in being vague.
+- **Do not repeat what Highlights or Technical changes already cover.** The summary is the "why" and the big picture; details live below.
 
-#### Technical details
+#### Highlights (only when applicable)
+- One bullet per user-facing feature, behavior change, or notable improvement.
+- Write from the user's perspective — what they'll notice, not internal implementation.
+- Plain language, no code references. "Schedules now respect your configured timezone" not "`SchedulerService` gains a `timezone` attribute".
+- 3-7 bullets is the sweet spot. If you can only think of 1-2, fold them into the summary and skip this section.
+
+#### Technical changes (inside the accordion)
 - One bullet per discrete change. Be specific — name files, classes, functions, patterns.
-- Format: `backtick code references` for identifiers, plain text for descriptions
+- Format: `backtick code references` for identifiers, plain text for descriptions.
 - Every meaningful change in the diff must have a bullet. If a change touches security (CORS, auth, SQL injection), error handling, accessibility, or concurrency, it gets its own bullet — do not bury these.
 - Bullets should describe the mechanism, not just the intent. "Race condition in `get_or_create_chat` fixed by moving creation inside the lookup session" is good. "Fix database issues" is not.
-- Order: roughly group related changes together (all typing fixes, all security hardening, all API changes, etc.)
+- Group related changes together (all typing fixes, all security hardening, all API changes, etc.)
 
 #### General
 - **No test plan section.** Do not include "Test plan" or "Testing".

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,6 @@ settings.local.json
 settings.json
 /feedback_connection
 /desktop/node_modules
-pr.md
+.pr/
 /.mypy_cache
 PROMPTURE_FEATURES.md

--- a/cachibot/api/room_websocket.py
+++ b/cachibot/api/room_websocket.py
@@ -7,7 +7,7 @@ import asyncio
 import copy
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -244,7 +244,7 @@ async def room_websocket_endpoint(
                     sender_id=user.id,
                     sender_name=user.username,
                     content=message_text,
-                    timestamp=datetime.utcnow(),
+                    timestamp=datetime.now(timezone.utc),
                 )
                 await msg_repo.save_message(user_msg)
 
@@ -1183,7 +1183,7 @@ async def run_room_bot(
                                 "id": event.data.get("id", ""),
                                 "tool": event.data["name"],
                                 "args": event.data.get("arguments", {}),
-                                "startTime": int(datetime.utcnow().timestamp() * 1000),
+                                "startTime": int(datetime.now(timezone.utc).timestamp() * 1000),
                             }
                         )
                         await room_manager.send_to_room(
@@ -1205,7 +1205,7 @@ async def run_room_bot(
                             if tc["id"] == tool_id:
                                 tc["result"] = str(event.data.get("result", ""))
                                 tc["success"] = event.data.get("success", True)
-                                tc["endTime"] = int(datetime.utcnow().timestamp() * 1000)
+                                tc["endTime"] = int(datetime.now(timezone.utc).timestamp() * 1000)
                                 break
                         await room_manager.send_to_room(
                             room_id,
@@ -1235,7 +1235,7 @@ async def run_room_bot(
                 sender_name=bot.name,
                 content=full_response,
                 metadata=metadata,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
             )
             await msg_repo.save_message(bot_msg)
 

--- a/cachibot/api/routes/auth.py
+++ b/cachibot/api/routes/auth.py
@@ -3,7 +3,7 @@
 import time
 import uuid
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
@@ -168,7 +168,7 @@ async def setup_initial_admin(request: SetupRequest) -> LoginResponse:
 
     # Create admin user
     auth_service = get_auth_service()
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     user = UserInDB(
         id=str(uuid.uuid4()),
@@ -263,7 +263,7 @@ async def login(request: LoginRequest) -> LoginResponse:
             is_active=user.is_active,
             created_at=user.created_at,
             created_by=user.created_by,
-            last_login=datetime.utcnow(),
+            last_login=datetime.now(timezone.utc),
         ),
     )
 
@@ -392,7 +392,7 @@ async def create_user(
         )
 
     # Create user
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     user = UserInDB(
         id=str(uuid.uuid4()),
         email=request.email.lower(),

--- a/cachibot/api/routes/bots.py
+++ b/cachibot/api/routes/bots.py
@@ -5,7 +5,7 @@ CRUD endpoints for syncing bot configuration from frontend.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -364,7 +364,7 @@ async def export_bot(
 
     return BotExportFormat(
         version="1.0",
-        exportedAt=datetime.utcnow().isoformat() + "Z",
+        exportedAt=datetime.now(timezone.utc).isoformat(),
         bot={
             "name": bot.name,
             "description": bot.description,
@@ -412,7 +412,7 @@ async def import_bot(
     import uuid
 
     new_id = str(uuid.uuid4())
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # Create the bot
     bot = Bot(

--- a/cachibot/api/routes/chat.py
+++ b/cachibot/api/routes/chat.py
@@ -1,7 +1,7 @@
 """Chat endpoints."""
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Request
 
@@ -40,7 +40,7 @@ async def send_message(
             id=message_id,
             role=MessageRole.USER,
             content=chat_request.message,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc),
         )
     )
 

--- a/cachibot/api/routes/connections.py
+++ b/cachibot/api/routes/connections.py
@@ -6,7 +6,7 @@ CRUD endpoints for managing bot platform connections.
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -125,7 +125,7 @@ async def create_connection(
     if errors:
         raise HTTPException(status_code=400, detail="; ".join(errors))
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     connection = BotConnection(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -178,7 +178,7 @@ async def update_connection(
         updated_config = {**connection.config, **body.config}
         connection.config = updated_config
 
-    connection.updated_at = datetime.utcnow()
+    connection.updated_at = datetime.now(timezone.utc)
     await repo.update_connection(connection)
     return ConnectionResponse.from_connection(connection)
 

--- a/cachibot/api/routes/contacts.py
+++ b/cachibot/api/routes/contacts.py
@@ -5,7 +5,7 @@ CRUD endpoints for managing bot contacts.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -79,7 +79,7 @@ async def create_contact(
     if not body.name.strip():
         raise HTTPException(status_code=400, detail="Contact name is required")
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     contact = Contact(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -122,7 +122,7 @@ async def update_contact(
 
     contact.name = body.name.strip()
     contact.details = body.details
-    contact.updated_at = datetime.utcnow()
+    contact.updated_at = datetime.now(timezone.utc)
 
     await repo.update_contact(contact)
     return ContactResponse.from_contact(contact)

--- a/cachibot/api/routes/documents.py
+++ b/cachibot/api/routes/documents.py
@@ -7,7 +7,7 @@ Endpoints for uploading, listing, and deleting bot documents.
 import hashlib
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated
 
@@ -140,7 +140,7 @@ async def upload_document(
         file_size=len(content),
         chunk_count=0,
         status=DocumentStatus.PROCESSING,
-        uploaded_at=datetime.utcnow(),
+        uploaded_at=datetime.now(timezone.utc),
     )
     await repo.save_document(doc)
 

--- a/cachibot/api/routes/knowledge.py
+++ b/cachibot/api/routes/knowledge.py
@@ -6,7 +6,7 @@ Notes CRUD, knowledge stats, search, document retry, and chunk preview.
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -81,7 +81,7 @@ async def create_note(
 ) -> NoteResponse:
     """Create a new note (source='user')."""
     repo = NotesRepository()
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     note = BotNote(
         id=str(uuid.uuid4()),
         bot_id=bot_id,

--- a/cachibot/api/routes/marketplace.py
+++ b/cachibot/api/routes/marketplace.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -397,7 +397,7 @@ async def install_template(
 
     # Generate new bot ID
     bot_id = str(uuid.uuid4())
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # Resolve model: use template's model if set, otherwise app default
     template_model = template_data.get("model", "")
@@ -557,7 +557,7 @@ async def install_room_template(
         else:
             # Install the bot template
             bot_id = str(uuid.uuid4())
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
 
             template_model = bot_template.get("model", "")
             if not template_model:
@@ -640,7 +640,7 @@ async def install_room_template(
     member_repo = RoomMemberRepository()
     room_bot_repo = RoomBotRepository()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     room = Room(
         id=str(uuid.uuid4()),
         title=template["name"],

--- a/cachibot/api/routes/providers.py
+++ b/cachibot/api/routes/providers.py
@@ -39,7 +39,14 @@ PROVIDERS: dict[str, dict[str, Any]] = {
     "azure": {
         "env_key": "AZURE_API_KEY",
         "type": "api_key",
-        "extra_keys": ["AZURE_API_ENDPOINT", "AZURE_DEPLOYMENT_ID"],
+        "extra_keys": [
+            "AZURE_API_ENDPOINT",
+            "AZURE_DEPLOYMENT_ID",
+            "AZURE_CLAUDE_API_KEY",
+            "AZURE_CLAUDE_ENDPOINT",
+            "AZURE_MISTRAL_API_KEY",
+            "AZURE_MISTRAL_ENDPOINT",
+        ],
     },
     "ollama": {
         "env_key": "OLLAMA_ENDPOINT",

--- a/cachibot/api/routes/rooms.py
+++ b/cachibot/api/routes/rooms.py
@@ -4,7 +4,7 @@ Endpoints for managing multi-agent rooms, membership, bots, and transcripts.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -80,7 +80,7 @@ async def create_room(
                 detail=f"Bot {bid} not found",
             )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     room = Room(
         id=str(uuid.uuid4()),
         title=data.title,
@@ -257,7 +257,7 @@ async def invite_member(
         user_id=target_user.id,
         username=target_user.username,
         role=RoomMemberRole.MEMBER,
-        joined_at=datetime.utcnow(),
+        joined_at=datetime.now(timezone.utc),
     )
     await member_repo.add_member(member)
 
@@ -320,7 +320,7 @@ async def add_bot(
         room_id=room_id,
         bot_id=data.bot_id,
         bot_name=bot.name,
-        added_at=datetime.utcnow(),
+        added_at=datetime.now(timezone.utc),
     )
     await bot_repo.add_bot(rb)
 

--- a/cachibot/api/routes/work.py
+++ b/cachibot/api/routes/work.py
@@ -5,7 +5,7 @@ Endpoints for managing work, tasks, jobs, todos, functions, and schedules.
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -589,7 +589,7 @@ async def create_function(
     user: User = Depends(require_bot_access_level(BotAccessLevel.EDITOR)),
 ) -> FunctionResponse:
     """Create a new function."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     fn = BotFunction(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -684,7 +684,7 @@ async def update_function(
             for p in request.parameters
         ]
 
-    fn.updated_at = datetime.utcnow()
+    fn.updated_at = datetime.now(timezone.utc)
     await function_repo.update(fn)
     return FunctionResponse.from_function(fn)
 
@@ -714,7 +714,7 @@ async def run_function(
     if fn is None or fn.bot_id != bot_id:
         raise HTTPException(status_code=404, detail="Function not found")
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     work_id = str(uuid.uuid4())
 
     # Create work from function
@@ -787,7 +787,7 @@ async def create_schedule(
     user: User = Depends(require_bot_access_level(BotAccessLevel.EDITOR)),
 ) -> ScheduleResponse:
     """Create a new schedule."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     schedule = Schedule(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -861,7 +861,7 @@ async def update_schedule(
     if request.catchUp is not None:
         schedule.catch_up = request.catchUp
 
-    schedule.updated_at = datetime.utcnow()
+    schedule.updated_at = datetime.now(timezone.utc)
     await schedule_repo.update(schedule)
     return ScheduleResponse.from_schedule(schedule)
 
@@ -945,7 +945,7 @@ async def create_work(
     user: User = Depends(require_bot_access_level(BotAccessLevel.EDITOR)),
 ) -> WorkResponse:
     """Create new work."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     work_id = str(uuid.uuid4())
 
     work = Work(
@@ -1086,7 +1086,7 @@ async def complete_work(
         raise HTTPException(status_code=404, detail="Work not found")
 
     work.status = WorkStatus.COMPLETED
-    work.completed_at = datetime.utcnow()
+    work.completed_at = datetime.now(timezone.utc)
     work.progress = 1.0
     if result:
         work.result = result
@@ -1212,7 +1212,7 @@ async def create_task(
         existing_tasks = await task_repo.get_by_work(work_id)
         order = max((t.order for t in existing_tasks), default=0) + 1
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     task = Task(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -1302,7 +1302,7 @@ async def start_task(
     attempt = len(existing_jobs) + 1
 
     # Create job
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     job = Job(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -1530,7 +1530,7 @@ async def create_todo(
     user: User = Depends(require_bot_access_level(BotAccessLevel.EDITOR)),
 ) -> TodoResponse:
     """Create a new todo."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     todo = Todo(
         id=str(uuid.uuid4()),
         bot_id=bot_id,
@@ -1637,7 +1637,7 @@ async def convert_todo_to_work(
     if todo is None or todo.bot_id != bot_id:
         raise HTTPException(status_code=404, detail="Todo not found")
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     work = Work(
         id=str(uuid.uuid4()),
         bot_id=bot_id,

--- a/cachibot/api/voice_websocket.py
+++ b/cachibot/api/voice_websocket.py
@@ -10,7 +10,7 @@ import copy
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 from prompture import StreamEventType
@@ -96,7 +96,7 @@ async def _run_voice_pipeline(
             chat_id=session.chat_id,
             role="user",
             content=transcript_text,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             metadata={"source": "voice"},
         )
         await repo.save_bot_message(user_msg)
@@ -210,7 +210,7 @@ async def _run_voice_pipeline(
             chat_id=session.chat_id,
             role="assistant",
             content=response_text,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             metadata={"source": "voice"},
         )
         await repo.save_bot_message(assistant_msg)

--- a/cachibot/api/websocket.py
+++ b/cachibot/api/websocket.py
@@ -9,7 +9,7 @@ import copy
 import logging
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -101,7 +101,8 @@ async def _resolve_bot_env(
             provider = effective_model.split("/", 1)[0].lower()
             api_key = resolved.provider_keys.get(provider)
             if api_key:
-                driver = build_driver_with_key(effective_model, api_key=api_key)
+                extras = resolved.provider_extras.get(provider, {})
+                driver = build_driver_with_key(effective_model, api_key=api_key, **extras)
 
         return resolved, driver
     except Exception:
@@ -379,7 +380,7 @@ async def run_agent(
                 chat_id=chat_id,
                 role="user",
                 content=message,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 reply_to_id=reply_to_id,
             )
             await repo.save_bot_message(user_msg)
@@ -438,7 +439,7 @@ async def run_agent(
                 chat_id=chat_id,
                 role="assistant",
                 content=response_text,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 reply_to_id=bot_reply_to,
             )
             await repo.save_bot_message(assistant_msg)

--- a/cachibot/models/automations.py
+++ b/cachibot/models/automations.py
@@ -1,6 +1,6 @@
 """Automation system Pydantic models: Scripts, Versions, Execution Logs, Timeline."""
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -86,8 +86,8 @@ class Script(BaseModel):
     status: ScriptStatus = Field(default=ScriptStatus.DRAFT)
     current_version: int = Field(default=1)
     tags: list[str] = Field(default_factory=list)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     created_by: str = Field(default="user")
     timeout_seconds: int = Field(default=300)
     max_memory_mb: int = Field(default=256)
@@ -111,7 +111,7 @@ class ScriptVersion(BaseModel):
     approved: bool = Field(default=False)
     approved_by: str | None = Field(default=None)
     approved_at: datetime | None = Field(default=None)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 # =============================================================================
@@ -125,7 +125,7 @@ class ExecutionLogLine(BaseModel):
     id: str = Field(description="Unique log line ID")
     execution_log_id: str = Field(description="Parent execution log")
     seq: int = Field(description="Sequence number for ordering")
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     level: LogLevel = Field(default=LogLevel.INFO)
     content: str = Field(description="Log content")
     data: dict[str, Any] | None = Field(default=None)
@@ -143,7 +143,7 @@ class ExecutionLog(BaseModel):
     user_id: str | None = Field(default=None)
     chat_id: str | None = Field(default=None)
     trigger: TriggerType = Field(default=TriggerType.MANUAL)
-    started_at: datetime = Field(default_factory=datetime.utcnow)
+    started_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     finished_at: datetime | None = Field(default=None)
     duration_ms: int | None = Field(default=None)
     status: ExecutionStatus = Field(default=ExecutionStatus.RUNNING)
@@ -176,7 +176,7 @@ class TimelineEvent(BaseModel):
     event_type: str = Field(
         description="Event: created, edited, version, execution, enabled, disabled, deleted"
     )
-    event_at: datetime = Field(default_factory=datetime.utcnow)
+    event_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     actor_type: str = Field(default="user")
     actor_id: str | None = Field(default=None)
     actor_name: str | None = Field(default=None)
@@ -214,7 +214,7 @@ class ExecutionDailySummary(BaseModel):
     total_credits: float = 0.0
     total_tokens: int = 0
     error_types: dict[str, int] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 # =============================================================================

--- a/cachibot/models/chat.py
+++ b/cachibot/models/chat.py
@@ -1,6 +1,6 @@
 """Chat-related Pydantic models."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -21,7 +21,7 @@ class ChatMessage(BaseModel):
     id: str = Field(description="Unique message ID")
     role: MessageRole = Field(description="Message role")
     content: str = Field(description="Message content")
-    timestamp: datetime = Field(default_factory=datetime.now)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/cachibot/models/command.py
+++ b/cachibot/models/command.py
@@ -5,7 +5,7 @@ Defines the data structures for the BotFather-like command system.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -49,14 +49,14 @@ class FlowState:
     command: str
     current_step: int = 0
     collected_data: dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime | None = None
 
     def is_expired(self) -> bool:
         """Check if the flow has expired."""
         if self.expires_at is None:
             return False
-        return datetime.utcnow() > self.expires_at
+        return datetime.now(timezone.utc) > self.expires_at
 
 
 @dataclass

--- a/cachibot/models/instruction.py
+++ b/cachibot/models/instruction.py
@@ -1,6 +1,6 @@
 """Pydantic models for custom instructions."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -26,8 +26,8 @@ class InstructionModel(BaseModel):
     is_active: bool = True
     category: str = "custom"
     tags: list[str] = Field(default_factory=list)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class InstructionVersionModel(BaseModel):
@@ -46,7 +46,7 @@ class InstructionVersionModel(BaseModel):
     few_shot_examples: list[dict[str, Any]] | None = None
     author: str
     commit_message: str | None = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class CreateInstructionRequest(BaseModel):

--- a/cachibot/models/job.py
+++ b/cachibot/models/job.py
@@ -7,7 +7,7 @@ Job-related Pydantic models.
     instead. This file will be removed in a future release.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -30,7 +30,7 @@ class Job(BaseModel):
     id: str = Field(description="Unique job ID")
     status: JobStatus = Field(default=JobStatus.PENDING)
     message_id: str | None = Field(default=None, description="Related message ID")
-    created_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     started_at: datetime | None = Field(default=None)
     completed_at: datetime | None = Field(default=None)
     result: Any | None = Field(default=None)

--- a/cachibot/models/work.py
+++ b/cachibot/models/work.py
@@ -1,6 +1,6 @@
 """Work management models: Functions, Schedules, Work, Tasks, Jobs, Todos."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -125,8 +125,8 @@ class BotFunction(BaseModel):
 
     # Metadata
     tags: list[str] = Field(default_factory=list)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Stats
     run_count: int = Field(default=0)
@@ -171,8 +171,8 @@ class Schedule(BaseModel):
     catch_up: bool = Field(default=False, description="Run missed executions on startup")
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     next_run_at: datetime | None = Field(default=None)
     last_run_at: datetime | None = Field(default=None)
     run_count: int = Field(default=0)
@@ -206,7 +206,7 @@ class Work(BaseModel):
     progress: float = Field(default=0.0, ge=0.0, le=1.0, description="0.0-1.0 derived from tasks")
 
     # Timing
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     started_at: datetime | None = Field(default=None)
     completed_at: datetime | None = Field(default=None)
     due_at: datetime | None = Field(default=None)
@@ -254,7 +254,7 @@ class Task(BaseModel):
     timeout_seconds: int | None = Field(default=None)
 
     # Timing
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     started_at: datetime | None = Field(default=None)
     completed_at: datetime | None = Field(default=None)
 
@@ -283,7 +283,7 @@ class Job(BaseModel):
     progress: float = Field(default=0.0, ge=0.0, le=1.0)
 
     # Timing
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     started_at: datetime | None = Field(default=None)
     completed_at: datetime | None = Field(default=None)
 
@@ -298,7 +298,7 @@ class Job(BaseModel):
 class JobLog(BaseModel):
     """A log entry for a job."""
 
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     level: str = Field(default="info", description="debug, info, warn, error")
     message: str = Field(description="Log message")
     data: Any | None = Field(default=None, description="Additional data")
@@ -325,7 +325,7 @@ class Todo(BaseModel):
     priority: Priority = Field(default=Priority.NORMAL)
 
     # Timing
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = Field(default=None)
     remind_at: datetime | None = Field(default=None, description="Optional reminder time")
 

--- a/cachibot/plugins/job_tools.py
+++ b/cachibot/plugins/job_tools.py
@@ -76,7 +76,7 @@ class JobToolsPlugin(CachibotPlugin):
             """
             import json
             import uuid
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             from cachibot.models.work import Priority, Task, TaskStatus, Work, WorkStatus
             from cachibot.storage.work_repository import TaskRepository, WorkRepository
@@ -99,7 +99,7 @@ class JobToolsPlugin(CachibotPlugin):
                     priority=Priority(priority) if priority else Priority.NORMAL,
                     status=WorkStatus.PENDING,
                     progress=0.0,
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                     context={},
                     tags=["job"],
                 )
@@ -119,7 +119,7 @@ class JobToolsPlugin(CachibotPlugin):
                             priority=Priority.NORMAL,
                             retry_count=0,
                             max_retries=3,
-                            created_at=datetime.utcnow(),
+                            created_at=datetime.now(timezone.utc),
                         )
                         await task_repo.save(task)
                         created_tasks.append({"id": task.id, "title": task.title})

--- a/cachibot/plugins/notes.py
+++ b/cachibot/plugins/notes.py
@@ -62,7 +62,7 @@ class NotesPlugin(CachibotPlugin):
             """
             import json
             import uuid
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             from cachibot.models.knowledge import BotNote, NoteSource
             from cachibot.storage.repository import NotesRepository
@@ -73,7 +73,7 @@ class NotesPlugin(CachibotPlugin):
 
             try:
                 repo = NotesRepository()
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
                 note = BotNote(
                     id=str(uuid.uuid4()),
                     bot_id=bot_id,

--- a/cachibot/plugins/work_management.py
+++ b/cachibot/plugins/work_management.py
@@ -97,7 +97,7 @@ class WorkManagementPlugin(CachibotPlugin):
             """
             import json
             import uuid
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             from cachibot.models.work import Priority, Task, TaskStatus, Work, WorkStatus
             from cachibot.storage.work_repository import TaskRepository, WorkRepository
@@ -119,7 +119,7 @@ class WorkManagementPlugin(CachibotPlugin):
                     priority=Priority(priority) if priority else Priority.NORMAL,
                     status=WorkStatus.PENDING,
                     progress=0.0,
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                     context={},
                     tags=[],
                 )
@@ -139,7 +139,7 @@ class WorkManagementPlugin(CachibotPlugin):
                             priority=Priority.NORMAL,
                             retry_count=0,
                             max_retries=3,
-                            created_at=datetime.utcnow(),
+                            created_at=datetime.now(timezone.utc),
                         )
                         await task_repo.save(task)
                         created_tasks.append({"id": task.id, "title": task.title})
@@ -339,7 +339,7 @@ class WorkManagementPlugin(CachibotPlugin):
             import json
             import re
             import uuid
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             from cachibot.models.work import Priority, Todo, TodoStatus
             from cachibot.storage.work_repository import TodoRepository
@@ -361,7 +361,7 @@ class WorkManagementPlugin(CachibotPlugin):
                         if time_match:
                             h, m = int(time_match.group(1)), int(time_match.group(2))
                             s = int(time_match.group(3)) if time_match.group(3) else 0
-                            now = datetime.utcnow()
+                            now = datetime.now(timezone.utc)
                             remind_datetime = now.replace(hour=h, minute=m, second=s, microsecond=0)
                             if remind_datetime <= now:
                                 # Time already passed today, schedule for tomorrow
@@ -384,7 +384,7 @@ class WorkManagementPlugin(CachibotPlugin):
                     notes=notes or None,
                     status=TodoStatus.OPEN,
                     priority=Priority(priority) if priority else Priority.NORMAL,
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                     remind_at=remind_datetime,
                     tags=[],
                 )
@@ -569,7 +569,7 @@ class WorkManagementPlugin(CachibotPlugin):
             import json
             import re
             import uuid
-            from datetime import datetime, timedelta
+            from datetime import datetime, timedelta, timezone
 
             from cachibot.models.work import Schedule, ScheduleType
             from cachibot.storage.work_repository import ScheduleRepository
@@ -589,7 +589,7 @@ class WorkManagementPlugin(CachibotPlugin):
                     if time_match:
                         h, m = int(time_match.group(1)), int(time_match.group(2))
                         s = int(time_match.group(3)) if time_match.group(3) else 0
-                        now = datetime.utcnow()
+                        now = datetime.now(timezone.utc)
                         run_at_dt = now.replace(hour=h, minute=m, second=s, microsecond=0)
                         if run_at_dt <= now:
                             run_at_dt += timedelta(days=1)
@@ -606,13 +606,13 @@ class WorkManagementPlugin(CachibotPlugin):
                 if interval_seconds < 60:
                     return "Error: Minimum interval is 60 seconds"
                 run_at_dt = None
-                next_run_at = datetime.utcnow() + timedelta(seconds=interval_seconds)
+                next_run_at = datetime.now(timezone.utc) + timedelta(seconds=interval_seconds)
             elif cron_expression:
                 schedule_type = ScheduleType.CRON
                 try:
                     from croniter import croniter
 
-                    cron = croniter(cron_expression, datetime.utcnow())
+                    cron = croniter(cron_expression, datetime.now(timezone.utc))
                     next_run_at = cron.get_next(datetime)
                 except (ValueError, KeyError) as e:
                     return f"Error: Invalid cron expression: {e}"
@@ -622,7 +622,7 @@ class WorkManagementPlugin(CachibotPlugin):
 
             try:
                 schedule_repo = ScheduleRepository()
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
                 schedule = Schedule(
                     id=str(uuid.uuid4()),
                     bot_id=bot_id,

--- a/cachibot/services/auth_service.py
+++ b/cachibot/services/auth_service.py
@@ -5,7 +5,7 @@ Handles password hashing and JWT token management.
 """
 
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import bcrypt
@@ -69,7 +69,7 @@ class AuthService:
         extra_claims: dict[str, Any] | None = None,
     ) -> str:
         """Create a JWT access token."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         expires = now + timedelta(minutes=self.config.access_token_expire_minutes)
 
         payload = {
@@ -91,7 +91,7 @@ class AuthService:
 
     def create_refresh_token(self, user_id: str) -> str:
         """Create a JWT refresh token."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         expires = now + timedelta(days=self.config.refresh_token_expire_days)
 
         payload = {
@@ -155,7 +155,7 @@ class AuthService:
         """Get the expiry time of a token."""
         payload = self.decode_token_unverified(token)
         if payload and "exp" in payload:
-            return datetime.utcfromtimestamp(payload["exp"])
+            return datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         return None
 
     # ===== Platform Launch Tokens (cloud mode) =====
@@ -172,7 +172,7 @@ class AuthService:
         if not self._platform_config or not self._platform_config.website_jwt_secret:
             raise ValueError("Platform JWT secret not configured")
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         payload = {
             "sub": email,
             "website_user_id": website_user_id,

--- a/cachibot/services/command_processor.py
+++ b/cachibot/services/command_processor.py
@@ -6,7 +6,7 @@ Handles BotFather-like slash commands for both web and platform interfaces.
 
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from cachibot.config import Config
@@ -79,8 +79,8 @@ class CommandProcessor:
             command=command,
             current_step=0,
             collected_data={},
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=FLOW_TIMEOUT_MINUTES),
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=FLOW_TIMEOUT_MINUTES),
         )
         self._flows[key] = flow
         return flow
@@ -424,7 +424,7 @@ class CommandProcessor:
 
         try:
             # Create the bot
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             try:
                 default_model = Config.load().agent.model
             except Exception:

--- a/cachibot/services/message_processor.py
+++ b/cachibot/services/message_processor.py
@@ -414,9 +414,7 @@ class MessageProcessor:
             # Use per_model keys from Prompture for the actual model used,
             # falling back to effective_model (resolved from bot config + app default)
             per_model = run_usage.get("per_model", {})
-            actual_model = (
-                next(iter(per_model)) if per_model else effective_model or bot.model
-            )
+            actual_model = next(iter(per_model)) if per_model else effective_model or bot.model
             usage_metadata: dict[str, Any] = {
                 "tokens": run_usage.get("total_tokens", 0),
                 "promptTokens": run_usage.get("prompt_tokens", 0),

--- a/cachibot/services/message_processor.py
+++ b/cachibot/services/message_processor.py
@@ -411,6 +411,12 @@ class MessageProcessor:
 
             # Save assistant response to history with usage metadata
             assistant_msg_id = str(uuid.uuid4())
+            # Use per_model keys from Prompture for the actual model used,
+            # falling back to effective_model (resolved from bot config + app default)
+            per_model = run_usage.get("per_model", {})
+            actual_model = (
+                next(iter(per_model)) if per_model else effective_model or bot.model
+            )
             usage_metadata: dict[str, Any] = {
                 "tokens": run_usage.get("total_tokens", 0),
                 "promptTokens": run_usage.get("prompt_tokens", 0),
@@ -420,7 +426,7 @@ class MessageProcessor:
                 "tokensPerSecond": run_usage.get("tokens_per_second", 0.0),
                 "callCount": run_usage.get("call_count", 0),
                 "errors": run_usage.get("errors", 0),
-                "model": bot.model,
+                "model": actual_model,
                 "platform": platform,
             }
             if tool_calls:

--- a/cachibot/services/message_processor.py
+++ b/cachibot/services/message_processor.py
@@ -8,7 +8,7 @@ import copy
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from prompture.exceptions import BudgetExceededError
@@ -284,7 +284,7 @@ class MessageProcessor:
             chat_id=chat_id,
             role="user",
             content=message,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             metadata=metadata,
         )
         await self._knowledge_repo.save_bot_message(user_msg)
@@ -432,7 +432,7 @@ class MessageProcessor:
                 chat_id=chat_id,
                 role="assistant",
                 content=response_text,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 metadata=usage_metadata,
             )
             await self._knowledge_repo.save_bot_message(assistant_msg)

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -298,8 +298,8 @@ function createWindow() {
 
 function createSplashWindow() {
   const splash = new BrowserWindow({
-    width: 400,
-    height: 300,
+    width: 420,
+    height: 340,
     frame: false,
     transparent: true,
     alwaysOnTop: true,
@@ -307,34 +307,13 @@ function createSplashWindow() {
     webPreferences: { nodeIntegration: false, contextIsolation: true },
   });
 
-  splash.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(`
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <style>
-        body {
-          margin: 0; display: flex; align-items: center; justify-content: center;
-          height: 100vh; background: #09090b; color: #a1a1aa; font-family: system-ui;
-          flex-direction: column; gap: 16px; border-radius: 12px;
-          -webkit-app-region: drag;
-        }
-        .title { font-size: 28px; font-weight: 700; color: #10b981; }
-        .subtitle { font-size: 14px; opacity: 0.7; }
-        .spinner {
-          width: 32px; height: 32px; border: 3px solid #27272a;
-          border-top-color: #10b981; border-radius: 50%;
-          animation: spin 0.8s linear infinite;
-        }
-        @keyframes spin { to { transform: rotate(360deg); } }
-      </style>
-    </head>
-    <body>
-      <div class="title">CachiBot</div>
-      <div class="spinner"></div>
-      <div class="subtitle">Starting the armored agent...</div>
-    </body>
-    </html>
-  `)}`);
+  const iconPath = path.join(__dirname, '..', 'assets', 'icon.png');
+  const iconUrl = `file://${iconPath.replace(/\\/g, '/')}`;
+  const version = require('./package.json').version;
+
+  splash.loadFile(path.join(__dirname, 'splash.html'), {
+    query: { icon: iconUrl, version },
+  });
 
   return splash;
 }

--- a/desktop/splash.html
+++ b/desktop/splash.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      height: 100vh;
+      background: #09090b;
+      color: #a1a1aa;
+      font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      border-radius: 12px;
+      overflow: hidden;
+      -webkit-app-region: drag;
+      user-select: none;
+      position: relative;
+    }
+
+    /* Subtle radial glow behind the icon */
+    body::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -60%);
+      width: 260px;
+      height: 260px;
+      background: radial-gradient(circle, rgba(16, 185, 129, 0.06) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      z-index: 1;
+    }
+
+    .icon {
+      width: 110px;
+      height: 110px;
+      margin-bottom: 8px;
+      animation: fadeIn 0.6s ease-out;
+      filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.4));
+    }
+
+    .app-name {
+      font-size: 26px;
+      font-weight: 700;
+      letter-spacing: 1.5px;
+      color: #e4e4e7;
+      animation: fadeIn 0.6s ease-out 0.15s both;
+    }
+
+    .version {
+      font-size: 11px;
+      font-weight: 500;
+      color: #52525b;
+      letter-spacing: 1px;
+      animation: fadeIn 0.6s ease-out 0.3s both;
+    }
+
+    /* Bottom section pinned to the bottom */
+    .bottom {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      padding: 0 32px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      animation: fadeIn 0.6s ease-out 0.45s both;
+    }
+
+    /* Progress bar track */
+    .progress-track {
+      width: 100%;
+      height: 2px;
+      background: #18181b;
+      border-radius: 1px;
+      overflow: hidden;
+    }
+
+    /* Indeterminate progress bar */
+    .progress-bar {
+      height: 100%;
+      width: 40%;
+      background: linear-gradient(90deg, transparent, #10b981, transparent);
+      border-radius: 1px;
+      animation: progress 1.8s ease-in-out infinite;
+    }
+
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .status-text {
+      font-size: 11px;
+      color: #52525b;
+      transition: opacity 0.3s ease;
+    }
+
+    .status-text.fade {
+      opacity: 0;
+    }
+
+    .tagline {
+      font-size: 10px;
+      color: #3f3f46;
+      letter-spacing: 0.5px;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes progress {
+      0%   { transform: translateX(-100%); }
+      100% { transform: translateX(350%); }
+    }
+  </style>
+</head>
+<body>
+  <div class="content">
+    <img class="icon" id="icon" alt="CachiBot">
+    <div class="app-name">CachiBot</div>
+    <div class="version" id="version"></div>
+  </div>
+
+  <div class="bottom">
+    <div class="progress-track">
+      <div class="progress-bar"></div>
+    </div>
+    <div class="status-row">
+      <span class="status-text" id="status">Initializing...</span>
+      <span class="tagline">The armored agent</span>
+    </div>
+  </div>
+
+  <script>
+    // Read query params passed from main process
+    const params = new URLSearchParams(window.location.search);
+    const iconPath = params.get('icon');
+    const version = params.get('version');
+
+    if (iconPath) document.getElementById('icon').src = iconPath;
+    if (version) document.getElementById('version').textContent = 'v' + version;
+
+    // Cycle through status messages
+    const messages = [
+      'Initializing...',
+      'Starting backend server...',
+      'Loading security modules...',
+      'Preparing workspace...',
+      'Almost ready...',
+    ];
+
+    let index = 0;
+    const statusEl = document.getElementById('status');
+
+    setInterval(() => {
+      statusEl.classList.add('fade');
+      setTimeout(() => {
+        index = (index + 1) % messages.length;
+        statusEl.textContent = messages[index];
+        statusEl.classList.remove('fade');
+      }, 300);
+    }, 3000);
+  </script>
+</body>
+</html>

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -248,10 +248,15 @@ export function useWebSocket() {
           const currentBot = useBotStore.getState().getActiveBot()
           const chatId = activeChatIdRef.current || pendingChatId
 
+          // Determine model from perModel breakdown (authoritative source from Prompture)
+          // Falls back to bot store model only when perModel is empty
+          const perModelKeys = Object.keys(payload.perModel || {})
+          const model = perModelKeys.length > 0 ? perModelKeys[0] : (currentBot?.model || 'unknown')
+
           // Record to dashboard usage stats
           useUsageStore.getState().recordUsage({
             botId: currentBotId || 'unknown',
-            model: currentBot?.model || 'unknown',
+            model,
             tokens: payload.totalTokens,
             cost: payload.totalCost,
           })
@@ -263,7 +268,7 @@ export function useWebSocket() {
               promptTokens: payload.promptTokens,
               completionTokens: payload.completionTokens,
               cost: payload.totalCost,
-              model: currentBot?.model,
+              model,
               iterations: payload.iterations,
               elapsedMs: payload.elapsedMs,
               tokensPerSecond: payload.tokensPerSecond,


### PR DESCRIPTION
Every `datetime.utcnow()` call in the codebase was living on borrowed deprecation warnings. This PR replaces all of them with timezone-aware `datetime.now(timezone.utc)` across 28 files — models, routes, services, plugins, and websockets — so timestamps actually know what timezone they belong to. On top of that, usage stats now report the model that actually ran the request (not the one configured on the bot), and the dashboard finally counts room activity alongside regular chats.

### Highlights

- Dashboard stats now include room messages and room counts alongside regular chats
- Usage metadata shows the actual model used per request, not just the bot's configured default
- Room WebSocket usage events are now tracked in the dashboard usage store
- Azure provider configuration supports additional per-backend keys and endpoints (Claude, Mistral)
- Desktop splash screen upgraded to a proper HTML file with app icon, version display, and animated progress bar

<details>
<summary>Technical changes</summary>

- Replaced all `datetime.utcnow()` and `datetime.now()` calls with `datetime.now(timezone.utc)` across 28 backend files (routes, models, services, plugins, websockets)
- Changed `default_factory=datetime.utcnow` in Pydantic/dataclass fields to `default_factory=lambda: datetime.now(timezone.utc)` in `automations.py`, `chat.py`, `command.py`, `instruction.py`, `job.py`, `work.py`
- Fixed `datetime.utcfromtimestamp()` in `auth_service.py` to use `datetime.fromtimestamp(ts, tz=timezone.utc)`
- Bot export timestamp in `routes/bots.py` now uses `.isoformat()` directly (already UTC-aware) instead of appending `"Z"` manually
- `message_processor.py` extracts the actual model from Prompture's `per_model` usage breakdown, falling back to `effective_model` or `bot.model`
- `useWebSocket.ts` reads model from `payload.perModel` keys instead of `currentBot?.model`, ensuring usage stats reflect the real model used
- `useRoomWebSocket.ts` now calls `useUsageStore.getState().recordUsage()` on `room_usage` events, previously these were not tracked in the dashboard
- `DashboardView.tsx` imports `useRoomStore`, aggregates `roomMessages` into total message count, counts room-based bot connections, and displays "X chats · Y rooms" in stat cards
- `PROVIDERS` dict in `routes/providers.py` expanded with `AZURE_CLAUDE_API_KEY`, `AZURE_CLAUDE_ENDPOINT`, `AZURE_MISTRAL_API_KEY`, `AZURE_MISTRAL_ENDPOINT`
- `bot_environment.py` adds `_PROVIDER_EXTRA_ENV_KEYS` mapping and `provider_extras` field on `ResolvedEnvironment`, loaded from both `os.environ` and bot-level overrides
- `websocket.py` passes `provider_extras` as kwargs to `build_driver_with_key()` so per-provider endpoints reach the driver
- Desktop splash screen extracted from inline data URL in `main.js` to `desktop/splash.html` with icon, version query params, progress bar, and cycling status messages

</details>
