### PR TITLE
Add coding agent streaming, mobile app features, and centralize agent construction

### DIFF
--- a/cachibot/api/room_websocket.py
+++ b/cachibot/api/room_websocket.py
@@ -1073,9 +1073,9 @@ async def run_room_bot(
             )
 
         # Resolve per-bot environment for budget enforcement and API keys
-        from cachibot.api.websocket import _resolve_bot_env
+        from cachibot.services.agent_factory import resolve_bot_env
 
-        resolved_env, per_bot_driver = await _resolve_bot_env(
+        resolved_env, per_bot_driver = await resolve_bot_env(
             bot_id,
             platform="web",
             effective_model=effective_model or agent_config.agent.model,

--- a/cachibot/api/routes/openai_compat.py
+++ b/cachibot/api/routes/openai_compat.py
@@ -20,8 +20,8 @@ from pydantic import BaseModel
 
 from cachibot.agent import CachibotAgent, load_disabled_capabilities, load_dynamic_instructions
 from cachibot.api.auth import resolve_api_key
-from cachibot.api.websocket import _resolve_bot_env
 from cachibot.config import Config
+from cachibot.services.agent_factory import resolve_bot_env
 from cachibot.storage.repository import BotRepository
 
 logger = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ async def chat_completions(
     agent_config = copy.deepcopy(config)
     agent_config.agent.model = effective_model
 
-    resolved_env, per_bot_driver = await _resolve_bot_env(
+    resolved_env, per_bot_driver = await resolve_bot_env(
         bot_id, platform="api", effective_model=effective_model
     )
 

--- a/cachibot/services/adapters/base.py
+++ b/cachibot/services/adapters/base.py
@@ -247,6 +247,44 @@ class BasePlatformAdapter(ABC):
         """
         pass
 
+    async def send_and_get_id(self, chat_id: str, message: str) -> str | None:
+        """Send a message and return its platform message ID.
+
+        Used by live-streaming features (e.g. coding agent sessions) to edit
+        the message later with progressive output updates.
+
+        Default implementation sends via send_message and returns None (no ID).
+        Subclasses should override to return the platform message ID.
+
+        Args:
+            chat_id: The chat/channel ID.
+            message: The message content.
+
+        Returns:
+            The platform message ID, or None if not supported.
+        """
+        await self.send_message(chat_id, message)
+        return None
+
+    async def edit_message(self, chat_id: str, message_id: str, text: str) -> bool:
+        """Edit a previously sent message in place.
+
+        Used by live-streaming features to update a message with progressive
+        output (e.g. a coding agent session showing real-time CLI output).
+
+        Default implementation returns False (not supported).
+        Subclasses should override for platforms that support message editing.
+
+        Args:
+            chat_id: The chat/channel ID.
+            message_id: The platform message ID (from send_and_get_id).
+            text: The new message content.
+
+        Returns:
+            True if edited successfully, False otherwise.
+        """
+        return False
+
     @classmethod
     def validate_config(cls, config: dict[str, str]) -> list[str]:
         """Validate platform-specific configuration.

--- a/cachibot/services/agent_factory.py
+++ b/cachibot/services/agent_factory.py
@@ -1,0 +1,213 @@
+"""
+Shared Agent Factory
+
+Centralizes CachibotAgent construction so that the web UI (websocket.py),
+platform providers (message_processor.py), and other call sites share a
+single pipeline for environment resolution, model overrides, tool config
+merging, context building, and dynamic instructions.
+"""
+
+import copy
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from cachibot.agent import CachibotAgent, load_disabled_capabilities, load_dynamic_instructions
+from cachibot.config import Config
+from cachibot.services.context_builder import get_context_builder
+from cachibot.services.driver_factory import build_driver_with_key
+
+logger = logging.getLogger(__name__)
+
+# Instruction block appended to the system prompt when the codingAgent
+# capability is enabled, telling the LLM how to handle @agent mentions.
+CODING_AGENT_MENTION_INSTRUCTIONS = """
+
+## Coding Agent @Mentions
+When the user @mentions a coding agent in their message (e.g. @claude, @codex, @gemini), \
+you MUST invoke the `coding_agent` tool with the matching `agent` parameter and pass the \
+user's request as the `task`. For example, if the user writes "@claude refactor this file", \
+call coding_agent(task="refactor this file", agent="claude"). If only "@" is used without a \
+specific agent name, use the default agent (omit the agent parameter).
+"""
+
+
+async def resolve_bot_env(
+    bot_id: str,
+    platform: str = "web",
+    effective_model: str = "",
+    request_overrides: dict[str, Any] | None = None,
+) -> tuple[Any, Any]:
+    """Resolve per-bot environment and build a driver.
+
+    Returns:
+        A tuple of (ResolvedEnvironment | None, driver | None).
+        On failure (DB unreachable, missing master key), returns (None, None)
+        and logs a warning so the agent falls back to global keys.
+    """
+    try:
+        from cachibot.services.bot_environment import BotEnvironmentService
+        from cachibot.services.encryption import get_encryption_service
+        from cachibot.storage.db import ensure_initialized
+
+        session_maker = ensure_initialized()
+        async with session_maker() as session:
+            encryption = get_encryption_service()
+            env_service = BotEnvironmentService(session, encryption)
+            resolved = await env_service.resolve(
+                bot_id, platform=platform, request_overrides=request_overrides
+            )
+
+        # Build a per-bot driver if we have a key for the effective provider
+        driver = None
+        if effective_model and "/" in effective_model:
+            provider = effective_model.split("/", 1)[0].lower()
+            api_key = resolved.provider_keys.get(provider)
+            if api_key:
+                extras = resolved.provider_extras.get(provider, {})
+                driver = build_driver_with_key(effective_model, api_key=api_key, **extras)
+
+        return resolved, driver
+    except Exception:
+        logger.warning(
+            "Per-bot environment resolution failed for bot %s; falling back to global keys",
+            bot_id,
+            exc_info=True,
+        )
+        return None, None
+
+
+def _inject_coding_agent_instructions(
+    prompt: str | None,
+    capabilities: dict[str, Any] | None,
+    disabled_caps: set[str],
+) -> str | None:
+    """Append @mention usage instructions when codingAgent is enabled."""
+    if not capabilities or not capabilities.get("codingAgent"):
+        return prompt
+    if "codingAgent" in disabled_caps:
+        return prompt
+    return (prompt or "") + CODING_AGENT_MENTION_INSTRUCTIONS
+
+
+async def build_bot_agent(
+    config: Config,
+    *,
+    # Identity
+    bot_id: str | None = None,
+    chat_id: str | None = None,
+    # System prompt — base prompt before context enrichment
+    base_system_prompt: str | None = None,
+    # Context building (enabled when user_message is provided)
+    user_message: str | None = None,
+    include_contacts: bool = False,
+    enabled_skills: list[str] | None = None,
+    # Bot config
+    capabilities: dict[str, Any] | None = None,
+    bot_models: dict[str, Any] | None = None,
+    tool_configs: dict[str, Any] | None = None,
+    # Platform
+    platform: str = "web",
+    platform_metadata: dict[str, Any] | None = None,
+    # Pre-resolved (skip internal resolution when caller already has these)
+    driver: Any | None = None,
+    provider_environment: Any | None = None,
+    disabled_capabilities: set[str] | None = None,
+    # Request overrides (web path passes per-request temp/max_tokens)
+    request_overrides: dict[str, Any] | None = None,
+    # Callbacks (passed through to CachibotAgent)
+    on_approval_needed: Callable[..., Any] | None = None,
+    on_instruction_delta: Callable[..., Any] | None = None,
+    on_model_fallback: Callable[..., Any] | None = None,
+    # Feature flags
+    inject_coding_agent: bool = False,
+) -> CachibotAgent:
+    """Build a fully-configured CachibotAgent.
+
+    This is the single entry point for constructing an agent with the full
+    shared pipeline: disabled-capability loading, model override, environment
+    resolution, tool-config merging, context building, coding-agent injection,
+    and dynamic instruction loading.
+    """
+    # 1. Disabled capabilities
+    if disabled_capabilities is None:
+        disabled_capabilities = await load_disabled_capabilities()
+
+    # 2. Model override — resolve effective model from bot_models["default"]
+    agent_config = config
+    effective_model: str | None = None
+    if bot_models and bot_models.get("default"):
+        effective_model = bot_models["default"]
+
+    if effective_model:
+        agent_config = copy.deepcopy(config)
+        agent_config.agent.model = effective_model
+
+    # 3. Environment resolution — if not pre-passed and bot_id exists
+    resolved_env = provider_environment
+    per_bot_driver = driver
+    if bot_id and resolved_env is None and per_bot_driver is None:
+        resolved_env, per_bot_driver = await resolve_bot_env(
+            bot_id,
+            platform=platform,
+            effective_model=effective_model or agent_config.agent.model,
+            request_overrides=request_overrides,
+        )
+
+    # 4. Tool config merging — merge resolved_env.skill_configs into tool_configs
+    merged_tool_configs = dict(tool_configs) if tool_configs else {}
+    if resolved_env and getattr(resolved_env, "skill_configs", None):
+        for skill_name, skill_cfg in resolved_env.skill_configs.items():
+            merged_tool_configs.setdefault(skill_name, {}).update(skill_cfg)
+
+    # 5. Context building — if user_message is provided
+    enhanced_prompt = base_system_prompt
+    if user_message and bot_id:
+        try:
+            context_builder = get_context_builder()
+            enhanced_prompt = await context_builder.build_enhanced_system_prompt(
+                base_prompt=base_system_prompt,
+                bot_id=bot_id,
+                user_message=user_message,
+                chat_id=chat_id,
+                include_contacts=include_contacts,
+                enabled_skills=enabled_skills,
+            )
+        except Exception as e:
+            logger.warning(
+                "Context building failed for bot %s chat %s: %s",
+                bot_id,
+                chat_id,
+                e,
+            )
+            enhanced_prompt = base_system_prompt
+
+    # 6. Coding agent injection
+    if inject_coding_agent:
+        enhanced_prompt = _inject_coding_agent_instructions(
+            enhanced_prompt, capabilities, disabled_capabilities
+        )
+
+    # 7. Construct CachibotAgent
+    agent = CachibotAgent(
+        config=agent_config,
+        system_prompt_override=enhanced_prompt,
+        capabilities=capabilities,
+        bot_id=bot_id,
+        chat_id=chat_id,
+        bot_models=bot_models,
+        tool_configs=merged_tool_configs,
+        on_approval_needed=on_approval_needed,
+        driver=per_bot_driver,
+        provider_environment=resolved_env,
+        disabled_capabilities=disabled_capabilities,
+        on_instruction_delta=on_instruction_delta,
+        on_model_fallback=on_model_fallback,
+        platform_metadata=platform_metadata,
+    )
+
+    # 8. Dynamic instructions
+    await load_dynamic_instructions(agent)
+
+    # 9. Return agent
+    return agent

--- a/cachibot/services/coding_agent_dispatcher.py
+++ b/cachibot/services/coding_agent_dispatcher.py
@@ -1,0 +1,479 @@
+"""
+Coding Agent Dispatcher
+
+Intercepts @claude/@codex/@gemini mentions on platform messages and spawns
+autonomous coding sessions with real-time output streaming back to the platform.
+
+Flow:
+  1. User sends "@claude fix the auth bug" on Telegram/Discord
+  2. PlatformManager detects the mention and delegates to this dispatcher
+  3. Dispatcher checks bot capabilities and CLI availability
+  4. Spawns the coding CLI as a subprocess in the bot's workspace
+  5. Streams stdout back to the platform via live message editing
+  6. Saves the conversation to message history and broadcasts to WebSocket
+"""
+
+import asyncio
+import logging
+import re
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from cachibot.config import Config
+from cachibot.models.knowledge import BotMessage
+from cachibot.models.platform import PlatformResponse
+from cachibot.plugins.coding_agent import _CLI_SPECS, CodingCLI, _resolve_binary
+from cachibot.storage.repository import BotRepository, ChatRepository, KnowledgeRepository
+
+logger = logging.getLogger(__name__)
+
+# Pattern: message must start with @agent followed by the task
+_MENTION_RE = re.compile(
+    r"^@(claude|codex|gemini)\s+(.+)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# How often to edit the live status message (seconds)
+_STREAM_INTERVAL = 3.0
+
+# Display names for the CLIs
+_CLI_DISPLAY: dict[CodingCLI, str] = {
+    CodingCLI.CLAUDE: "Claude Code",
+    CodingCLI.CODEX: "Codex CLI",
+    CodingCLI.GEMINI: "Gemini CLI",
+}
+
+
+class SessionStatus(str, Enum):
+    """Status of a coding agent session."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    ERROR = "error"
+
+
+@dataclass
+class CodingSession:
+    """Tracks an active coding agent subprocess."""
+
+    id: str
+    cli: CodingCLI
+    task: str
+    connection_id: str
+    bot_id: str
+    chat_id: str  # Platform chat/channel ID (used for adapter sends)
+    internal_chat_id: str  # Internal DB chat ID (used for message storage)
+    platform: str
+    status: SessionStatus = SessionStatus.RUNNING
+    start_time: float = field(default_factory=time.time)
+    output_lines: list[str] = field(default_factory=list)
+    _cancel: threading.Event = field(default_factory=threading.Event)
+    _proc: subprocess.Popen | None = field(default=None, repr=False)
+
+    @property
+    def elapsed_str(self) -> str:
+        s = int(time.time() - self.start_time)
+        return f"{s // 60}m{s % 60}s" if s >= 60 else f"{s}s"
+
+    @property
+    def full_output(self) -> str:
+        return "".join(self.output_lines).strip()
+
+    def cancel(self) -> None:
+        """Cancel the running session and kill the subprocess."""
+        self._cancel.set()
+        if self._proc:
+            try:
+                self._proc.kill()
+            except OSError:
+                pass
+        self.status = SessionStatus.CANCELLED
+
+
+class CodingAgentDispatcher:
+    """Dispatches @mention coding agent sessions on platform adapters.
+
+    Intercepts messages like "@claude fix the auth bug" from Telegram/Discord,
+    spawns the appropriate coding CLI, and streams output back via live
+    message editing.
+    """
+
+    def __init__(self) -> None:
+        # Active sessions keyed by "{connection_id}:{chat_id}"
+        self._sessions: dict[str, CodingSession] = {}
+        self._config = Config.load()
+        self._bot_repo = BotRepository()
+        self._chat_repo = ChatRepository()
+        self._knowledge_repo = KnowledgeRepository()
+
+    @staticmethod
+    def _key(connection_id: str, chat_id: str) -> str:
+        return f"{connection_id}:{chat_id}"
+
+    @staticmethod
+    def parse_mention(message: str) -> tuple[str, str] | None:
+        """Parse an @agent mention at the start of a message.
+
+        Returns:
+            (agent_name, task) tuple, or None if not an @mention.
+        """
+        m = _MENTION_RE.match(message.strip())
+        return (m.group(1).lower(), m.group(2).strip()) if m else None
+
+    def has_active_session(self, connection_id: str, chat_id: str) -> bool:
+        """Check if there's a running coding session for this chat."""
+        s = self._sessions.get(self._key(connection_id, chat_id))
+        return s is not None and s.status == SessionStatus.RUNNING
+
+    def cancel_session(self, connection_id: str, chat_id: str) -> bool:
+        """Cancel an active coding session. Returns True if a session was cancelled."""
+        s = self._sessions.get(self._key(connection_id, chat_id))
+        if s and s.status == SessionStatus.RUNNING:
+            s.cancel()
+            return True
+        return False
+
+    async def try_dispatch(
+        self,
+        message: str,
+        connection_id: str,
+        bot_id: str,
+        chat_id: str,
+        metadata: dict[str, Any],
+        adapter: Any,
+    ) -> PlatformResponse | None:
+        """Try to dispatch a coding agent session for an @mention.
+
+        Args:
+            message: The raw user message.
+            connection_id: The platform connection ID.
+            bot_id: The bot ID.
+            chat_id: The platform chat/channel ID.
+            metadata: Platform-specific metadata.
+            adapter: The platform adapter (BasePlatformAdapter).
+
+        Returns:
+            PlatformResponse if the message was handled (empty — messages sent
+            directly via adapter), or None to fall through to normal processing.
+        """
+        parsed = self.parse_mention(message)
+        if not parsed:
+            return None
+
+        agent_name, task = parsed
+
+        # --- Capability gate ---
+        bot = await self._bot_repo.get_bot(bot_id)
+        if not bot:
+            return PlatformResponse(text="Bot not found.")
+
+        capabilities = bot.capabilities or {}
+        if not capabilities.get("codingAgent"):
+            return None  # Fall through to normal LLM processing
+
+        from cachibot.agent import load_disabled_capabilities
+
+        if "codingAgent" in await load_disabled_capabilities():
+            return None
+
+        # --- Resolve CLI ---
+        try:
+            cli = CodingCLI(agent_name)
+        except ValueError:
+            available = ", ".join(c.value for c in CodingCLI)
+            return PlatformResponse(text=f"Unknown agent '{agent_name}'. Available: {available}")
+
+        ca_config = self._config.coding_agents
+        path_map = {
+            CodingCLI.CLAUDE: ca_config.claude_path,
+            CodingCLI.CODEX: ca_config.codex_path,
+            CodingCLI.GEMINI: ca_config.gemini_path,
+        }
+        binary = path_map.get(cli, "") or _resolve_binary(cli.value)
+        if not binary:
+            return PlatformResponse(text=f"{cli.value} is not installed or not on PATH.")
+
+        # --- Session guard ---
+        key = self._key(connection_id, chat_id)
+        if self.has_active_session(connection_id, chat_id):
+            return PlatformResponse(
+                text="A coding session is already running. Send /cancel to stop it."
+            )
+
+        # --- Resolve internal chat ID for message history ---
+        platform = metadata.get("platform", "unknown")
+        username = metadata.get("username") or metadata.get("first_name") or "User"
+        chat_obj = await self._chat_repo.get_or_create_platform_chat(
+            bot_id=bot_id,
+            platform=platform,
+            platform_chat_id=chat_id,
+            title=f"{platform.title()}: {username}",
+        )
+        if not chat_obj:
+            return PlatformResponse()  # Archived chat
+
+        # --- Create session ---
+        session = CodingSession(
+            id=str(uuid.uuid4())[:8],
+            cli=cli,
+            task=task,
+            connection_id=connection_id,
+            bot_id=bot_id,
+            chat_id=chat_id,
+            internal_chat_id=chat_obj.id,
+            platform=platform,
+        )
+        self._sessions[key] = session
+
+        # --- Save user message to history ---
+        user_msg_id = str(uuid.uuid4())
+        await self._knowledge_repo.save_bot_message(
+            BotMessage(
+                id=user_msg_id,
+                bot_id=bot_id,
+                chat_id=chat_obj.id,
+                role="user",
+                content=message,
+                timestamp=datetime.now(timezone.utc),
+                metadata=metadata,
+            )
+        )
+        await self._ws_broadcast(bot_id, chat_obj.id, "user", message, user_msg_id, platform)
+
+        # --- Send initial status message ---
+        display = _CLI_DISPLAY.get(cli, cli.value)
+        status_text = f"Starting {display} session...\n\nTask: {task}"
+        live_id = await adapter.send_and_get_id(chat_id, status_text)
+
+        # --- Run CLI with streaming ---
+        result = await self._run_session(session, binary, display, adapter, live_id)
+
+        # --- Finalize ---
+        if session.status == SessionStatus.RUNNING:
+            session.status = SessionStatus.COMPLETED
+        self._sessions.pop(key, None)
+
+        # Update the live message with final status
+        icon = {
+            SessionStatus.COMPLETED: "done",
+            SessionStatus.CANCELLED: "cancelled",
+            SessionStatus.ERROR: "error",
+        }.get(session.status, "done")
+        if live_id:
+            await adapter.edit_message(
+                chat_id, live_id, f"{display} — {icon} ({session.elapsed_str})"
+            )
+
+        # Send full output as a new message
+        if session.status == SessionStatus.CANCELLED:
+            final = f"Session cancelled after {session.elapsed_str}."
+        else:
+            final = result
+
+        if final:
+            await adapter.send_message(chat_id, final)
+
+        # --- Save assistant message to history ---
+        asst_id = str(uuid.uuid4())
+        await self._knowledge_repo.save_bot_message(
+            BotMessage(
+                id=asst_id,
+                bot_id=bot_id,
+                chat_id=chat_obj.id,
+                role="assistant",
+                content=final,
+                timestamp=datetime.now(timezone.utc),
+                metadata={
+                    "codingAgent": agent_name,
+                    "sessionId": session.id,
+                    "status": session.status.value,
+                    "elapsed": session.elapsed_str,
+                    "platform": platform,
+                },
+            )
+        )
+        await self._ws_broadcast(
+            bot_id,
+            chat_obj.id,
+            "assistant",
+            final,
+            asst_id,
+            platform,
+            metadata={"codingAgent": agent_name, "sessionId": session.id},
+        )
+
+        return PlatformResponse()  # Already sent via adapter
+
+    async def _run_session(
+        self,
+        session: CodingSession,
+        binary: str,
+        display: str,
+        adapter: Any,
+        live_id: str | None,
+    ) -> str:
+        """Run the coding CLI subprocess with live output streaming.
+
+        Spawns the CLI in a thread, collects stdout line-by-line, and
+        periodically edits the live status message on the platform.
+
+        Returns:
+            The CLI output text.
+        """
+        ca = self._config.coding_agents
+        spec = _CLI_SPECS[session.cli]
+        build_args = spec["build_args"]
+        args = build_args(session.task, ca.max_turns)  # type: ignore[operator]
+        cwd = str(self._config.workspace_path.resolve())
+
+        if not Path(cwd).is_dir():
+            session.status = SessionStatus.ERROR
+            return f"Workspace directory not found: {cwd}"
+
+        # --- Start periodic live-message editing ---
+        edit_task: asyncio.Task[None] | None = None
+        if live_id:
+
+            async def _live_edit() -> None:
+                """Edit the live message with the latest output tail."""
+                while session.status == SessionStatus.RUNNING:
+                    await asyncio.sleep(_STREAM_INTERVAL)
+                    if session.status != SessionStatus.RUNNING:
+                        break
+                    output = session.full_output
+                    if not output:
+                        continue
+                    header = f"{display} — running ({session.elapsed_str})\n"
+                    separator = "\n"
+                    avail = adapter.max_message_length - len(header) - len(separator) - 10
+                    if len(output) > avail:
+                        output = "..." + output[-avail:]
+                    try:
+                        await adapter.edit_message(
+                            session.chat_id, live_id, header + separator + output
+                        )
+                    except Exception:
+                        pass
+
+            edit_task = asyncio.create_task(_live_edit())
+
+        # --- Run subprocess in a thread ---
+        timed_out = threading.Event()
+
+        def _run_sync() -> tuple[int, str]:
+            try:
+                proc = subprocess.Popen(
+                    [binary, *args],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    cwd=cwd,
+                )
+                session._proc = proc
+            except OSError as exc:
+                session.status = SessionStatus.ERROR
+                return -1, f"Failed to start '{binary}': {exc}"
+
+            # Watchdog thread: kills the process on timeout or user cancel
+            def _watchdog() -> None:
+                if not session._cancel.wait(ca.timeout_seconds):
+                    # Timed out (cancel was NOT set within the timeout)
+                    timed_out.set()
+                    try:
+                        proc.kill()
+                    except OSError:
+                        pass
+
+            threading.Thread(target=_watchdog, daemon=True).start()
+
+            # Read stdout line-by-line
+            try:
+                if proc.stdout:
+                    for raw_line in proc.stdout:
+                        session.output_lines.append(raw_line.decode(errors="replace"))
+            except Exception:
+                pass
+
+            proc.wait()
+            session._cancel.set()  # Stop the watchdog
+            session._proc = None
+
+            if session.status == SessionStatus.CANCELLED:
+                return -1, session.full_output
+
+            if timed_out.is_set():
+                return -1, f"Timed out after {ca.timeout_seconds}s.\n\n{session.full_output}"
+
+            return proc.returncode or 0, session.full_output
+
+        try:
+            returncode, output = await asyncio.to_thread(_run_sync)
+        except Exception as exc:
+            session.status = SessionStatus.ERROR
+            returncode, output = -1, f"Error: {type(exc).__name__}: {exc}"
+        finally:
+            if edit_task:
+                edit_task.cancel()
+                try:
+                    await edit_task
+                except asyncio.CancelledError:
+                    pass
+
+        # Truncate if needed
+        if len(output) > ca.max_output_length:
+            output = output[: ca.max_output_length] + "\n\n... (truncated)"
+
+        if session.status == SessionStatus.CANCELLED:
+            return output
+
+        if returncode != 0 and session.status != SessionStatus.ERROR:
+            session.status = SessionStatus.ERROR
+
+        return output or f"{display} completed (no output)."
+
+    async def _ws_broadcast(
+        self,
+        bot_id: str,
+        chat_id: str,
+        role: str,
+        content: str,
+        message_id: str,
+        platform: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Broadcast a message to connected WebSocket clients."""
+        try:
+            from cachibot.api.websocket import get_ws_manager
+            from cachibot.models.websocket import WSMessage
+
+            msg = WSMessage.platform_message(
+                bot_id=bot_id,
+                chat_id=chat_id,
+                role=role,
+                content=content,
+                message_id=message_id,
+                platform=platform,
+                metadata=metadata,
+            )
+            await get_ws_manager().broadcast(msg)
+        except Exception:
+            pass
+
+
+# Singleton
+_dispatcher: CodingAgentDispatcher | None = None
+
+
+def get_coding_agent_dispatcher() -> CodingAgentDispatcher:
+    """Get the singleton coding agent dispatcher instance."""
+    global _dispatcher
+    if _dispatcher is None:
+        _dispatcher = CodingAgentDispatcher()
+    return _dispatcher

--- a/cachibot/services/coding_agent_dispatcher.py
+++ b/cachibot/services/coding_agent_dispatcher.py
@@ -76,7 +76,7 @@ class CodingSession:
     start_time: float = field(default_factory=time.time)
     output_lines: list[str] = field(default_factory=list)
     _cancel: threading.Event = field(default_factory=threading.Event)
-    _proc: subprocess.Popen | None = field(default=None, repr=False)
+    _proc: subprocess.Popen[bytes] | None = field(default=None, repr=False)
 
     @property
     def elapsed_str(self) -> str:

--- a/cachibot/services/job_runner.py
+++ b/cachibot/services/job_runner.py
@@ -389,9 +389,9 @@ class JobRunnerService:
         driver = None
         provider_environment = None
         try:
-            from cachibot.api.websocket import _resolve_bot_env
+            from cachibot.services.agent_factory import resolve_bot_env
 
-            resolved_env, resolved_driver = await _resolve_bot_env(
+            resolved_env, resolved_driver = await resolve_bot_env(
                 bot.id, effective_model=config.agent.model
             )
             if resolved_env:

--- a/cachibot/services/ntfy.py
+++ b/cachibot/services/ntfy.py
@@ -1,0 +1,159 @@
+"""ntfy push notification service for CachiBot.
+
+Dispatches notifications to a self-hosted ntfy server when the mobile
+client's WebSocket connection is not available. The mobile app subscribes
+to its user-specific topic via SSE and shows local notifications.
+
+Configuration (cachibot.toml):
+    [ntfy]
+    server_url = "https://ntfy.example.com"
+    # Topic prefix — actual topic is "{prefix}-{user_id}"
+    topic_prefix = "cachibot"
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class NtfyService:
+    """HTTP client for pushing notifications to an ntfy server."""
+
+    def __init__(self, server_url: str, topic_prefix: str = "cachibot") -> None:
+        self.server_url = server_url.rstrip("/")
+        self.topic_prefix = topic_prefix
+        self._client = httpx.AsyncClient(timeout=10)
+
+    def _topic(self, user_id: str) -> str:
+        return f"{self.topic_prefix}-{user_id}"
+
+    async def send(
+        self,
+        user_id: str,
+        message: str,
+        *,
+        title: str = "CachiBot",
+        tags: list[str] | None = None,
+        priority: int = 3,
+        click_url: str | None = None,
+        extras: dict[str, Any] | None = None,
+    ) -> bool:
+        """Push a notification to the user's ntfy topic.
+
+        Args:
+            user_id: Target user ID (determines the topic).
+            message: Notification body text.
+            title: Notification title.
+            tags: ntfy tags (used for emoji and routing on mobile).
+            priority: 1 (min) to 5 (max), default 3 (normal).
+            click_url: URL to open when the notification is tapped.
+            extras: Additional JSON data attached to the message.
+
+        Returns:
+            True if the notification was delivered, False otherwise.
+        """
+        topic = self._topic(user_id)
+        url = f"{self.server_url}/{topic}"
+
+        headers: dict[str, str] = {
+            "Title": title,
+            "Priority": str(priority),
+        }
+        if tags:
+            headers["Tags"] = ",".join(tags)
+        if click_url:
+            headers["Click"] = click_url
+
+        try:
+            response = await self._client.post(
+                url,
+                content=message,
+                headers=headers,
+            )
+            if response.status_code in (200, 202):
+                logger.debug("ntfy sent to %s: %s", topic, title)
+                return True
+
+            logger.warning(
+                "ntfy returned %d for topic %s: %s",
+                response.status_code,
+                topic,
+                response.text[:200],
+            )
+            return False
+
+        except httpx.HTTPError as exc:
+            logger.error("ntfy send failed for %s: %s", topic, exc)
+            return False
+
+    # ---- Convenience methods ----
+
+    async def send_message(
+        self,
+        user_id: str,
+        bot_name: str,
+        content: str,
+        *,
+        chat_route: str | None = None,
+    ) -> bool:
+        """Notify about a new bot message."""
+        return await self.send(
+            user_id,
+            content[:200] if len(content) > 200 else content,
+            title=bot_name,
+            tags=["message", "speech_balloon"],
+            click_url=chat_route,
+        )
+
+    async def send_approval_request(
+        self,
+        user_id: str,
+        tool_name: str,
+        risk_level: str = "medium",
+    ) -> bool:
+        """Notify about a pending approval request."""
+        return await self.send(
+            user_id,
+            f"Bot wants to use: {tool_name} (risk: {risk_level})",
+            title="Approval Required",
+            tags=["approval", "warning"],
+            priority=4,
+        )
+
+    async def send_work_update(
+        self,
+        user_id: str,
+        work_title: str,
+        status: str,
+    ) -> bool:
+        """Notify about a work/job status change."""
+        return await self.send(
+            user_id,
+            f"{work_title}: {status}",
+            title="Work Update",
+            tags=["work", "hammer"],
+        )
+
+    async def send_reminder(
+        self,
+        user_id: str,
+        title: str,
+        body: str,
+    ) -> bool:
+        """Send a scheduled reminder notification."""
+        return await self.send(
+            user_id,
+            body,
+            title=title,
+            tags=["reminder", "bell"],
+            priority=4,
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,23 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <!-- Share intent: receive text -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+
+            <!-- Share intent: receive files (PDF, documents) -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/pdf" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/markdown" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/mobile/lib/core/router.dart
+++ b/mobile/lib/core/router.dart
@@ -6,11 +6,15 @@ import '../providers/auth_provider.dart';
 import '../screens/auth/biometric_lock_screen.dart';
 import '../screens/auth/login_screen.dart';
 import '../screens/auth/qr_pair_screen.dart';
-import '../screens/chat/chat_list_screen.dart';
+import '../screens/bot/bot_detail_screen.dart';
 import '../screens/chat/chat_screen.dart';
 import '../screens/chat/recent_chats_screen.dart';
 import '../screens/home/home_screen.dart';
+import '../screens/knowledge/knowledge_search_screen.dart';
+import '../screens/knowledge/note_editor_screen.dart';
 import '../screens/settings/settings_screen.dart';
+import '../screens/work/todos_screen.dart';
+import '../screens/work/work_detail_screen.dart';
 import '../widgets/common/app_shell.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -67,9 +71,51 @@ final routerProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/bot/:botId',
-            builder: (context, state) => ChatListScreen(
+            builder: (context, state) => BotDetailScreen(
               botId: state.pathParameters['botId']!,
             ),
+            routes: [
+              // Knowledge routes
+              GoRoute(
+                path: 'knowledge/new',
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => NoteEditorScreen(
+                  botId: state.pathParameters['botId']!,
+                ),
+              ),
+              GoRoute(
+                path: 'knowledge/search',
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => KnowledgeSearchScreen(
+                  botId: state.pathParameters['botId']!,
+                ),
+              ),
+              GoRoute(
+                path: 'knowledge/:noteId',
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => NoteEditorScreen(
+                  botId: state.pathParameters['botId']!,
+                  noteId: state.pathParameters['noteId'],
+                ),
+              ),
+              // Work routes
+              GoRoute(
+                path: 'work/:workId',
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => WorkDetailScreen(
+                  botId: state.pathParameters['botId']!,
+                  workId: state.pathParameters['workId']!,
+                ),
+              ),
+              // Todos route
+              GoRoute(
+                path: 'todos',
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (context, state) => TodosScreen(
+                  botId: state.pathParameters['botId']!,
+                ),
+              ),
+            ],
           ),
           GoRoute(
             path: '/chat/:botId',

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,14 +1,22 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/router.dart';
 import 'providers/auth_provider.dart';
 import 'providers/theme_provider.dart';
+import 'services/notifications/notification_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
+
+  // Initialize notification service early
+  await notificationService.init();
 
   runApp(
     ProviderScope(
@@ -28,6 +36,9 @@ class CachiBotApp extends ConsumerStatefulWidget {
 }
 
 class _CachiBotAppState extends ConsumerState<CachiBotApp> {
+  StreamSubscription<List<SharedMediaFile>>? _shareSub;
+  String? _pendingSharedText;
+
   @override
   void initState() {
     super.initState();
@@ -35,6 +46,53 @@ class _CachiBotAppState extends ConsumerState<CachiBotApp> {
     Future.microtask(() {
       ref.read(authProvider.notifier).restoreSession();
     });
+
+    // Handle shared content from other apps
+    _initShareIntents();
+  }
+
+  void _initShareIntents() {
+    // Handle share when app is already running
+    _shareSub = ReceiveSharingIntent.instance.getMediaStream().listen(
+      (files) => _handleSharedFiles(files),
+      onError: (_) {},
+    );
+
+    // Handle share that launched the app
+    ReceiveSharingIntent.instance.getInitialMedia().then((files) {
+      if (files.isNotEmpty) {
+        _handleSharedFiles(files);
+        ReceiveSharingIntent.instance.reset();
+      }
+    });
+  }
+
+  void _handleSharedFiles(List<SharedMediaFile> files) {
+    if (files.isEmpty) return;
+
+    final router = ref.read(routerProvider);
+
+    for (final file in files) {
+      if (file.type == SharedMediaType.text ||
+          file.type == SharedMediaType.url) {
+        // Shared text: navigate to recent chats with text pre-filled
+        // User can pick a bot/chat from there
+        _pendingSharedText = file.path;
+        router.go('/chats');
+        break;
+      } else if (file.type == SharedMediaType.file) {
+        // Shared file: could be a document to upload
+        // For now, just navigate home — the user picks a bot
+        router.go('/');
+        break;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _shareSub?.cancel();
+    super.dispose();
   }
 
   @override
@@ -43,6 +101,9 @@ class _CachiBotAppState extends ConsumerState<CachiBotApp> {
     final lightTheme = ref.watch(lightThemeProvider);
     final darkTheme = ref.watch(darkThemeProvider);
     final router = ref.watch(routerProvider);
+
+    // Pass router to notification service for tap navigation
+    notificationService.init(router: router);
 
     return MaterialApp.router(
       title: 'CachiBot',

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -37,7 +36,6 @@ class CachiBotApp extends ConsumerStatefulWidget {
 
 class _CachiBotAppState extends ConsumerState<CachiBotApp> {
   StreamSubscription<List<SharedMediaFile>>? _shareSub;
-  String? _pendingSharedText;
 
   @override
   void initState() {
@@ -77,7 +75,8 @@ class _CachiBotAppState extends ConsumerState<CachiBotApp> {
           file.type == SharedMediaType.url) {
         // Shared text: navigate to recent chats with text pre-filled
         // User can pick a bot/chat from there
-        _pendingSharedText = file.path;
+        // TODO: pass shared text to the chat screen
+
         router.go('/chats');
         break;
       } else if (file.type == SharedMediaType.file) {

--- a/mobile/lib/models/knowledge.dart
+++ b/mobile/lib/models/knowledge.dart
@@ -1,0 +1,182 @@
+class BotNote {
+  const BotNote({
+    required this.id,
+    required this.botId,
+    required this.title,
+    required this.content,
+    this.tags = const [],
+    required this.source,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String botId;
+  final String title;
+  final String content;
+  final List<String> tags;
+  final String source;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory BotNote.fromJson(Map<String, dynamic> json) {
+    return BotNote(
+      id: json['id'] as String,
+      botId: json['botId'] as String? ?? json['bot_id'] as String,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      tags: (json['tags'] as List<dynamic>?)?.cast<String>() ?? [],
+      source: json['source'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String? ?? json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String? ?? json['updated_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'botId': botId,
+        'title': title,
+        'content': content,
+        'tags': tags,
+        'source': source,
+        'createdAt': createdAt.toIso8601String(),
+        'updatedAt': updatedAt.toIso8601String(),
+      };
+
+  BotNote copyWith({
+    String? title,
+    String? content,
+    List<String>? tags,
+  }) {
+    return BotNote(
+      id: id,
+      botId: botId,
+      title: title ?? this.title,
+      content: content ?? this.content,
+      tags: tags ?? this.tags,
+      source: source,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+}
+
+class KnowledgeDocument {
+  const KnowledgeDocument({
+    required this.id,
+    required this.filename,
+    required this.fileType,
+    required this.fileSize,
+    required this.chunkCount,
+    required this.status,
+    required this.uploadedAt,
+    this.processedAt,
+  });
+
+  final String id;
+  final String filename;
+  final String fileType;
+  final int fileSize;
+  final int chunkCount;
+  final String status;
+  final DateTime uploadedAt;
+  final DateTime? processedAt;
+
+  factory KnowledgeDocument.fromJson(Map<String, dynamic> json) {
+    return KnowledgeDocument(
+      id: json['id'] as String,
+      filename: json['filename'] as String,
+      fileType: json['fileType'] as String? ?? json['file_type'] as String,
+      fileSize: json['fileSize'] as int? ?? json['file_size'] as int,
+      chunkCount: json['chunkCount'] as int? ?? json['chunk_count'] as int? ?? 0,
+      status: json['status'] as String,
+      uploadedAt: DateTime.parse(
+        json['uploadedAt'] as String? ?? json['uploaded_at'] as String,
+      ),
+      processedAt: json['processedAt'] != null
+          ? DateTime.parse(json['processedAt'] as String)
+          : json['processed_at'] != null
+              ? DateTime.parse(json['processed_at'] as String)
+              : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'filename': filename,
+        'fileType': fileType,
+        'fileSize': fileSize,
+        'chunkCount': chunkCount,
+        'status': status,
+        'uploadedAt': uploadedAt.toIso8601String(),
+        'processedAt': processedAt?.toIso8601String(),
+      };
+
+  bool get isReady => status == 'ready';
+  bool get isProcessing => status == 'processing';
+  bool get isFailed => status == 'failed';
+}
+
+class KnowledgeStats {
+  const KnowledgeStats({
+    required this.totalDocuments,
+    required this.documentsReady,
+    required this.documentsProcessing,
+    required this.documentsFailed,
+    required this.totalChunks,
+    required this.totalNotes,
+    this.hasInstructions = false,
+  });
+
+  final int totalDocuments;
+  final int documentsReady;
+  final int documentsProcessing;
+  final int documentsFailed;
+  final int totalChunks;
+  final int totalNotes;
+  final bool hasInstructions;
+
+  factory KnowledgeStats.fromJson(Map<String, dynamic> json) {
+    return KnowledgeStats(
+      totalDocuments: json['totalDocuments'] as int? ?? json['total_documents'] as int? ?? 0,
+      documentsReady: json['documentsReady'] as int? ?? json['documents_ready'] as int? ?? 0,
+      documentsProcessing:
+          json['documentsProcessing'] as int? ?? json['documents_processing'] as int? ?? 0,
+      documentsFailed:
+          json['documentsFailed'] as int? ?? json['documents_failed'] as int? ?? 0,
+      totalChunks: json['totalChunks'] as int? ?? json['total_chunks'] as int? ?? 0,
+      totalNotes: json['totalNotes'] as int? ?? json['total_notes'] as int? ?? 0,
+      hasInstructions:
+          json['hasInstructions'] as bool? ?? json['has_instructions'] as bool? ?? false,
+    );
+  }
+}
+
+class SearchResult {
+  const SearchResult({
+    required this.type,
+    required this.id,
+    required this.title,
+    required this.content,
+    this.score,
+    this.source,
+  });
+
+  final String type;
+  final String id;
+  final String title;
+  final String content;
+  final double? score;
+  final String? source;
+
+  factory SearchResult.fromJson(Map<String, dynamic> json) {
+    return SearchResult(
+      type: json['type'] as String,
+      id: json['id'] as String,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      score: (json['score'] as num?)?.toDouble(),
+      source: json['source'] as String?,
+    );
+  }
+}

--- a/mobile/lib/models/work.dart
+++ b/mobile/lib/models/work.dart
@@ -1,0 +1,544 @@
+enum WorkStatus {
+  pending,
+  inProgress,
+  completed,
+  failed,
+  cancelled,
+  paused;
+
+  static WorkStatus fromString(String value) {
+    switch (value) {
+      case 'in_progress':
+        return WorkStatus.inProgress;
+      default:
+        return WorkStatus.values.firstWhere(
+          (e) => e.name == value,
+          orElse: () => WorkStatus.pending,
+        );
+    }
+  }
+
+  String toApi() {
+    switch (this) {
+      case WorkStatus.inProgress:
+        return 'in_progress';
+      default:
+        return name;
+    }
+  }
+}
+
+enum TaskStatus {
+  pending,
+  ready,
+  inProgress,
+  completed,
+  failed,
+  blocked,
+  skipped;
+
+  static TaskStatus fromString(String value) {
+    switch (value) {
+      case 'in_progress':
+        return TaskStatus.inProgress;
+      default:
+        return TaskStatus.values.firstWhere(
+          (e) => e.name == value,
+          orElse: () => TaskStatus.pending,
+        );
+    }
+  }
+
+  String toApi() {
+    switch (this) {
+      case TaskStatus.inProgress:
+        return 'in_progress';
+      default:
+        return name;
+    }
+  }
+}
+
+enum JobStatus {
+  pending,
+  running,
+  completed,
+  failed,
+  cancelled;
+
+  static JobStatus fromString(String value) {
+    return JobStatus.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => JobStatus.pending,
+    );
+  }
+}
+
+enum TodoStatus {
+  open,
+  done,
+  dismissed;
+
+  static TodoStatus fromString(String value) {
+    return TodoStatus.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => TodoStatus.open,
+    );
+  }
+}
+
+enum Priority {
+  low,
+  normal,
+  high,
+  urgent;
+
+  static Priority fromString(String value) {
+    return Priority.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => Priority.normal,
+    );
+  }
+}
+
+class BotWork {
+  const BotWork({
+    required this.id,
+    required this.botId,
+    this.chatId,
+    required this.title,
+    this.description,
+    this.goal,
+    this.functionId,
+    this.scheduleId,
+    this.parentWorkId,
+    required this.status,
+    required this.priority,
+    required this.progress,
+    required this.createdAt,
+    this.startedAt,
+    this.completedAt,
+    this.dueAt,
+    this.result,
+    this.error,
+    this.context,
+    this.tags = const [],
+    this.taskCount,
+    this.completedTaskCount,
+  });
+
+  final String id;
+  final String botId;
+  final String? chatId;
+  final String title;
+  final String? description;
+  final String? goal;
+  final String? functionId;
+  final String? scheduleId;
+  final String? parentWorkId;
+  final WorkStatus status;
+  final Priority priority;
+  final double progress;
+  final DateTime createdAt;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final DateTime? dueAt;
+  final String? result;
+  final String? error;
+  final Map<String, dynamic>? context;
+  final List<String> tags;
+  final int? taskCount;
+  final int? completedTaskCount;
+
+  factory BotWork.fromJson(Map<String, dynamic> json) {
+    return BotWork(
+      id: json['id'] as String,
+      botId: json['botId'] as String,
+      chatId: json['chatId'] as String?,
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      goal: json['goal'] as String?,
+      functionId: json['functionId'] as String?,
+      scheduleId: json['scheduleId'] as String?,
+      parentWorkId: json['parentWorkId'] as String?,
+      status: WorkStatus.fromString(json['status'] as String),
+      priority: Priority.fromString(json['priority'] as String? ?? 'normal'),
+      progress: (json['progress'] as num?)?.toDouble() ?? 0.0,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      startedAt: json['startedAt'] != null
+          ? DateTime.parse(json['startedAt'] as String)
+          : null,
+      completedAt: json['completedAt'] != null
+          ? DateTime.parse(json['completedAt'] as String)
+          : null,
+      dueAt: json['dueAt'] != null
+          ? DateTime.parse(json['dueAt'] as String)
+          : null,
+      result: json['result'] as String?,
+      error: json['error'] as String?,
+      context: json['context'] as Map<String, dynamic>?,
+      tags: (json['tags'] as List<dynamic>?)?.cast<String>() ?? [],
+      taskCount: json['taskCount'] as int?,
+      completedTaskCount: json['completedTaskCount'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'botId': botId,
+        'chatId': chatId,
+        'title': title,
+        'description': description,
+        'goal': goal,
+        'status': status.toApi(),
+        'priority': priority.name,
+        'progress': progress,
+        'createdAt': createdAt.toIso8601String(),
+        'startedAt': startedAt?.toIso8601String(),
+        'completedAt': completedAt?.toIso8601String(),
+        'dueAt': dueAt?.toIso8601String(),
+        'tags': tags,
+      };
+
+  BotWork copyWith({
+    String? title,
+    String? description,
+    String? goal,
+    WorkStatus? status,
+    Priority? priority,
+    double? progress,
+    int? taskCount,
+    int? completedTaskCount,
+  }) {
+    return BotWork(
+      id: id,
+      botId: botId,
+      chatId: chatId,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      goal: goal ?? this.goal,
+      functionId: functionId,
+      scheduleId: scheduleId,
+      parentWorkId: parentWorkId,
+      status: status ?? this.status,
+      priority: priority ?? this.priority,
+      progress: progress ?? this.progress,
+      createdAt: createdAt,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      dueAt: dueAt,
+      result: result,
+      error: error,
+      context: context,
+      tags: tags,
+      taskCount: taskCount ?? this.taskCount,
+      completedTaskCount: completedTaskCount ?? this.completedTaskCount,
+    );
+  }
+
+  bool get isActive =>
+      status == WorkStatus.pending || status == WorkStatus.inProgress;
+  bool get isDone => status == WorkStatus.completed;
+  bool get hasFailed => status == WorkStatus.failed;
+}
+
+class WorkTask {
+  const WorkTask({
+    required this.id,
+    required this.botId,
+    required this.workId,
+    this.chatId,
+    required this.title,
+    this.description,
+    this.action,
+    this.order = 0,
+    this.dependsOn = const [],
+    required this.status,
+    required this.priority,
+    this.retryCount = 0,
+    this.maxRetries = 0,
+    this.timeoutSeconds,
+    required this.createdAt,
+    this.startedAt,
+    this.completedAt,
+    this.result,
+    this.error,
+  });
+
+  final String id;
+  final String botId;
+  final String workId;
+  final String? chatId;
+  final String title;
+  final String? description;
+  final String? action;
+  final int order;
+  final List<String> dependsOn;
+  final TaskStatus status;
+  final Priority priority;
+  final int retryCount;
+  final int maxRetries;
+  final int? timeoutSeconds;
+  final DateTime createdAt;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final String? result;
+  final String? error;
+
+  factory WorkTask.fromJson(Map<String, dynamic> json) {
+    return WorkTask(
+      id: json['id'] as String,
+      botId: json['botId'] as String,
+      workId: json['workId'] as String,
+      chatId: json['chatId'] as String?,
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      action: json['action'] as String?,
+      order: json['order'] as int? ?? 0,
+      dependsOn: (json['dependsOn'] as List<dynamic>?)?.cast<String>() ?? [],
+      status: TaskStatus.fromString(json['status'] as String),
+      priority: Priority.fromString(json['priority'] as String? ?? 'normal'),
+      retryCount: json['retryCount'] as int? ?? 0,
+      maxRetries: json['maxRetries'] as int? ?? 0,
+      timeoutSeconds: json['timeoutSeconds'] as int?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      startedAt: json['startedAt'] != null
+          ? DateTime.parse(json['startedAt'] as String)
+          : null,
+      completedAt: json['completedAt'] != null
+          ? DateTime.parse(json['completedAt'] as String)
+          : null,
+      result: json['result'] as String?,
+      error: json['error'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'botId': botId,
+        'workId': workId,
+        'title': title,
+        'description': description,
+        'action': action,
+        'order': order,
+        'dependsOn': dependsOn,
+        'status': status.toApi(),
+        'priority': priority.name,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  WorkTask copyWith({
+    String? title,
+    String? description,
+    TaskStatus? status,
+    Priority? priority,
+    String? result,
+    String? error,
+  }) {
+    return WorkTask(
+      id: id,
+      botId: botId,
+      workId: workId,
+      chatId: chatId,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      action: action,
+      order: order,
+      dependsOn: dependsOn,
+      status: status ?? this.status,
+      priority: priority ?? this.priority,
+      retryCount: retryCount,
+      maxRetries: maxRetries,
+      timeoutSeconds: timeoutSeconds,
+      createdAt: createdAt,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      result: result ?? this.result,
+      error: error ?? this.error,
+    );
+  }
+
+  bool get isRunning => status == TaskStatus.inProgress;
+  bool get isDone => status == TaskStatus.completed;
+  bool get hasFailed => status == TaskStatus.failed;
+}
+
+class Job {
+  const Job({
+    required this.id,
+    required this.botId,
+    required this.taskId,
+    required this.workId,
+    this.chatId,
+    required this.status,
+    required this.attempt,
+    required this.progress,
+    required this.createdAt,
+    this.startedAt,
+    this.completedAt,
+    this.result,
+    this.error,
+    this.logs = const [],
+  });
+
+  final String id;
+  final String botId;
+  final String taskId;
+  final String workId;
+  final String? chatId;
+  final JobStatus status;
+  final int attempt;
+  final double progress;
+  final DateTime createdAt;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final String? result;
+  final String? error;
+  final List<JobLog> logs;
+
+  factory Job.fromJson(Map<String, dynamic> json) {
+    return Job(
+      id: json['id'] as String,
+      botId: json['botId'] as String,
+      taskId: json['taskId'] as String,
+      workId: json['workId'] as String,
+      chatId: json['chatId'] as String?,
+      status: JobStatus.fromString(json['status'] as String),
+      attempt: json['attempt'] as int? ?? 1,
+      progress: (json['progress'] as num?)?.toDouble() ?? 0.0,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      startedAt: json['startedAt'] != null
+          ? DateTime.parse(json['startedAt'] as String)
+          : null,
+      completedAt: json['completedAt'] != null
+          ? DateTime.parse(json['completedAt'] as String)
+          : null,
+      result: json['result'] as String?,
+      error: json['error'] as String?,
+      logs: (json['logs'] as List<dynamic>?)
+              ?.map((e) => JobLog.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+  }
+}
+
+class JobLog {
+  const JobLog({
+    required this.timestamp,
+    required this.level,
+    required this.message,
+    this.data,
+  });
+
+  final DateTime timestamp;
+  final String level;
+  final String message;
+  final Map<String, dynamic>? data;
+
+  factory JobLog.fromJson(Map<String, dynamic> json) {
+    return JobLog(
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      level: json['level'] as String,
+      message: json['message'] as String,
+      data: json['data'] as Map<String, dynamic>?,
+    );
+  }
+}
+
+class Todo {
+  const Todo({
+    required this.id,
+    required this.botId,
+    this.chatId,
+    required this.title,
+    this.notes,
+    required this.status,
+    required this.priority,
+    required this.createdAt,
+    this.completedAt,
+    this.remindAt,
+    this.convertedToWorkId,
+    this.convertedToTaskId,
+    this.tags = const [],
+  });
+
+  final String id;
+  final String botId;
+  final String? chatId;
+  final String title;
+  final String? notes;
+  final TodoStatus status;
+  final Priority priority;
+  final DateTime createdAt;
+  final DateTime? completedAt;
+  final DateTime? remindAt;
+  final String? convertedToWorkId;
+  final String? convertedToTaskId;
+  final List<String> tags;
+
+  factory Todo.fromJson(Map<String, dynamic> json) {
+    return Todo(
+      id: json['id'] as String,
+      botId: json['botId'] as String,
+      chatId: json['chatId'] as String?,
+      title: json['title'] as String,
+      notes: json['notes'] as String?,
+      status: TodoStatus.fromString(json['status'] as String),
+      priority: Priority.fromString(json['priority'] as String? ?? 'normal'),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      completedAt: json['completedAt'] != null
+          ? DateTime.parse(json['completedAt'] as String)
+          : null,
+      remindAt: json['remindAt'] != null
+          ? DateTime.parse(json['remindAt'] as String)
+          : null,
+      convertedToWorkId: json['convertedToWorkId'] as String?,
+      convertedToTaskId: json['convertedToTaskId'] as String?,
+      tags: (json['tags'] as List<dynamic>?)?.cast<String>() ?? [],
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'botId': botId,
+        'chatId': chatId,
+        'title': title,
+        'notes': notes,
+        'status': status.name,
+        'priority': priority.name,
+        'createdAt': createdAt.toIso8601String(),
+        'completedAt': completedAt?.toIso8601String(),
+        'remindAt': remindAt?.toIso8601String(),
+        'tags': tags,
+      };
+
+  Todo copyWith({
+    String? title,
+    String? notes,
+    TodoStatus? status,
+    Priority? priority,
+    DateTime? remindAt,
+    List<String>? tags,
+  }) {
+    return Todo(
+      id: id,
+      botId: botId,
+      chatId: chatId,
+      title: title ?? this.title,
+      notes: notes ?? this.notes,
+      status: status ?? this.status,
+      priority: priority ?? this.priority,
+      createdAt: createdAt,
+      completedAt: completedAt,
+      remindAt: remindAt ?? this.remindAt,
+      convertedToWorkId: convertedToWorkId,
+      convertedToTaskId: convertedToTaskId,
+      tags: tags ?? this.tags,
+    );
+  }
+
+  bool get isOpen => status == TodoStatus.open;
+  bool get isDone => status == TodoStatus.done;
+  bool get isDismissed => status == TodoStatus.dismissed;
+}

--- a/mobile/lib/providers/knowledge_provider.dart
+++ b/mobile/lib/providers/knowledge_provider.dart
@@ -1,0 +1,236 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/knowledge.dart';
+import 'service_providers.dart';
+
+class KnowledgeState {
+  const KnowledgeState({
+    this.notes = const [],
+    this.documents = const [],
+    this.stats,
+    this.searchResults = const [],
+    this.searchQuery = '',
+    this.isLoading = false,
+    this.errorMessage,
+    this.isOffline = false,
+  });
+
+  final List<BotNote> notes;
+  final List<KnowledgeDocument> documents;
+  final KnowledgeStats? stats;
+  final List<SearchResult> searchResults;
+  final String searchQuery;
+  final bool isLoading;
+  final String? errorMessage;
+  final bool isOffline;
+
+  KnowledgeState copyWith({
+    List<BotNote>? notes,
+    List<KnowledgeDocument>? documents,
+    KnowledgeStats? stats,
+    List<SearchResult>? searchResults,
+    String? searchQuery,
+    bool? isLoading,
+    String? errorMessage,
+    bool clearError = false,
+    bool? isOffline,
+  }) {
+    return KnowledgeState(
+      notes: notes ?? this.notes,
+      documents: documents ?? this.documents,
+      stats: stats ?? this.stats,
+      searchResults: searchResults ?? this.searchResults,
+      searchQuery: searchQuery ?? this.searchQuery,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      isOffline: isOffline ?? this.isOffline,
+    );
+  }
+}
+
+class KnowledgeNotifier extends StateNotifier<KnowledgeState> {
+  KnowledgeNotifier(this._ref) : super(const KnowledgeState());
+
+  final Ref _ref;
+
+  Future<void> loadNotes(String botId, {List<String>? tags, String? search}) async {
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final notes = await service.listNotes(botId, tags: tags, search: search);
+      state = state.copyWith(notes: notes, isLoading: false, isOffline: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: _extractError(e),
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: e.toString());
+    }
+  }
+
+  Future<void> loadDocuments(String botId) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final docs = await service.listDocuments(botId);
+      state = state.copyWith(documents: docs);
+    } catch (_) {}
+  }
+
+  Future<void> loadStats(String botId) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final stats = await service.getStats(botId);
+      state = state.copyWith(stats: stats);
+    } catch (_) {}
+  }
+
+  Future<void> loadAll(String botId) async {
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final results = await Future.wait([
+        service.listNotes(botId),
+        service.listDocuments(botId),
+        service.getStats(botId),
+      ]);
+      state = KnowledgeState(
+        notes: results[0] as List<BotNote>,
+        documents: results[1] as List<KnowledgeDocument>,
+        stats: results[2] as KnowledgeStats,
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: _extractError(e),
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: e.toString());
+    }
+  }
+
+  Future<BotNote?> createNote(
+    String botId, {
+    required String title,
+    required String content,
+    List<String> tags = const [],
+  }) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final note = await service.createNote(
+        botId,
+        title: title,
+        content: content,
+        tags: tags,
+      );
+      state = state.copyWith(notes: [note, ...state.notes]);
+      return note;
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+      return null;
+    }
+  }
+
+  Future<BotNote?> updateNote(
+    String botId,
+    String noteId, {
+    String? title,
+    String? content,
+    List<String>? tags,
+  }) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final updated = await service.updateNote(
+        botId,
+        noteId,
+        title: title,
+        content: content,
+        tags: tags,
+      );
+      state = state.copyWith(
+        notes: state.notes.map((n) => n.id == noteId ? updated : n).toList(),
+      );
+      return updated;
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+      return null;
+    }
+  }
+
+  Future<void> deleteNote(String botId, String noteId) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      await service.deleteNote(botId, noteId);
+      state = state.copyWith(
+        notes: state.notes.where((n) => n.id != noteId).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> search(String botId, String query) async {
+    if (query.isEmpty) {
+      state = state.copyWith(searchResults: [], searchQuery: '');
+      return;
+    }
+    state = state.copyWith(searchQuery: query, isLoading: true);
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      final results = await service.search(botId, query);
+      state = state.copyWith(searchResults: results, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: _extractError(e),
+      );
+    }
+  }
+
+  Future<void> uploadDocument(String botId, String filePath, String fileName) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      await service.uploadDocument(botId, filePath, fileName);
+      await loadDocuments(botId);
+      await loadStats(botId);
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> deleteDocument(String botId, String docId) async {
+    try {
+      final service = _ref.read(knowledgeServiceProvider);
+      await service.deleteDocument(botId, docId);
+      state = state.copyWith(
+        documents: state.documents.where((d) => d.id != docId).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  void clearError() {
+    state = state.copyWith(clearError: true);
+  }
+
+  String _extractError(DioException e) {
+    final data = e.response?.data;
+    if (data is Map<String, dynamic> && data.containsKey('detail')) {
+      final detail = data['detail'];
+      if (detail is String) return detail;
+      if (detail is Map) return detail['message']?.toString() ?? 'Request failed';
+    }
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.connectionError) {
+      return 'Cannot reach server';
+    }
+    return 'Request failed';
+  }
+}
+
+final knowledgeProvider =
+    StateNotifierProvider<KnowledgeNotifier, KnowledgeState>((ref) {
+  return KnowledgeNotifier(ref);
+});

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/api/api_client.dart';
 import '../services/api/bot_service.dart';
+import '../services/api/knowledge_service.dart';
+import '../services/api/work_service.dart';
 import '../services/auth/auth_service.dart';
 import '../services/database/app_database.dart';
 import '../services/database/chat_dao.dart';
@@ -30,6 +32,16 @@ final authServiceProvider = Provider<AuthService>((ref) {
 final botServiceProvider = Provider<BotService>((ref) {
   final client = ref.watch(apiClientProvider);
   return BotService(client);
+});
+
+final knowledgeServiceProvider = Provider<KnowledgeService>((ref) {
+  final client = ref.watch(apiClientProvider);
+  return KnowledgeService(client);
+});
+
+final workServiceProvider = Provider<WorkService>((ref) {
+  final client = ref.watch(apiClientProvider);
+  return WorkService(client);
 });
 
 final wsServiceProvider = Provider<WebSocketService>((ref) {

--- a/mobile/lib/providers/tasks_provider.dart
+++ b/mobile/lib/providers/tasks_provider.dart
@@ -1,0 +1,171 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/work.dart';
+import 'service_providers.dart';
+
+class TasksState {
+  const TasksState({
+    this.tasks = const [],
+    this.isLoading = false,
+    this.errorMessage,
+  });
+
+  final List<WorkTask> tasks;
+  final bool isLoading;
+  final String? errorMessage;
+
+  TasksState copyWith({
+    List<WorkTask>? tasks,
+    bool? isLoading,
+    String? errorMessage,
+    bool clearError = false,
+  }) {
+    return TasksState(
+      tasks: tasks ?? this.tasks,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+    );
+  }
+}
+
+class TasksNotifier extends StateNotifier<TasksState> {
+  TasksNotifier(this._ref) : super(const TasksState());
+
+  final Ref _ref;
+
+  Future<void> loadTasks(String botId, String workId) async {
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      final service = _ref.read(workServiceProvider);
+      final tasks = await service.listTasks(botId, workId);
+      tasks.sort((a, b) => a.order.compareTo(b.order));
+      state = state.copyWith(tasks: tasks, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: _extractError(e));
+    } catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: e.toString());
+    }
+  }
+
+  Future<WorkTask?> createTask(
+    String botId,
+    String workId, {
+    required String title,
+    String? description,
+    String? priority,
+  }) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final task = await service.createTask(
+        botId,
+        workId,
+        title: title,
+        description: description,
+        priority: priority,
+      );
+      state = state.copyWith(tasks: [...state.tasks, task]);
+      return task;
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+      return null;
+    }
+  }
+
+  Future<void> updateTask(
+    String botId,
+    String taskId, {
+    String? title,
+    String? description,
+    String? status,
+    String? priority,
+  }) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.updateTask(
+        botId,
+        taskId,
+        title: title,
+        description: description,
+        status: status,
+        priority: priority,
+      );
+      state = state.copyWith(
+        tasks: state.tasks.map((t) => t.id == taskId ? updated : t).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> startTask(String botId, String taskId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.startTask(botId, taskId);
+      state = state.copyWith(
+        tasks: state.tasks.map((t) => t.id == taskId ? updated : t).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> completeTask(String botId, String taskId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.completeTask(botId, taskId);
+      state = state.copyWith(
+        tasks: state.tasks.map((t) => t.id == taskId ? updated : t).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> failTask(String botId, String taskId, {String? error}) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.failTask(botId, taskId, error: error);
+      state = state.copyWith(
+        tasks: state.tasks.map((t) => t.id == taskId ? updated : t).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> deleteTask(String botId, String taskId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      await service.deleteTask(botId, taskId);
+      state = state.copyWith(
+        tasks: state.tasks.where((t) => t.id != taskId).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  void clear() {
+    state = const TasksState();
+  }
+
+  String _extractError(DioException e) {
+    final data = e.response?.data;
+    if (data is Map<String, dynamic> && data.containsKey('detail')) {
+      final detail = data['detail'];
+      if (detail is String) return detail;
+      if (detail is Map) return detail['message']?.toString() ?? 'Request failed';
+    }
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.connectionError) {
+      return 'Cannot reach server';
+    }
+    return 'Request failed';
+  }
+}
+
+final tasksProvider =
+    StateNotifierProvider<TasksNotifier, TasksState>((ref) {
+  return TasksNotifier(ref);
+});

--- a/mobile/lib/providers/todos_provider.dart
+++ b/mobile/lib/providers/todos_provider.dart
@@ -1,0 +1,176 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/work.dart';
+import 'service_providers.dart';
+
+enum TodoFilter { open, done, all }
+
+class TodosState {
+  const TodosState({
+    this.todos = const [],
+    this.isLoading = false,
+    this.errorMessage,
+    this.filter = TodoFilter.open,
+  });
+
+  final List<Todo> todos;
+  final bool isLoading;
+  final String? errorMessage;
+  final TodoFilter filter;
+
+  TodosState copyWith({
+    List<Todo>? todos,
+    bool? isLoading,
+    String? errorMessage,
+    bool clearError = false,
+    TodoFilter? filter,
+  }) {
+    return TodosState(
+      todos: todos ?? this.todos,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      filter: filter ?? this.filter,
+    );
+  }
+
+  List<Todo> get filteredTodos {
+    switch (filter) {
+      case TodoFilter.open:
+        return todos.where((t) => t.isOpen).toList();
+      case TodoFilter.done:
+        return todos.where((t) => t.isDone || t.isDismissed).toList();
+      case TodoFilter.all:
+        return todos;
+    }
+  }
+}
+
+class TodosNotifier extends StateNotifier<TodosState> {
+  TodosNotifier(this._ref) : super(const TodosState());
+
+  final Ref _ref;
+
+  Future<void> loadTodos(String botId) async {
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      final service = _ref.read(workServiceProvider);
+      final todos = await service.listTodos(botId);
+      state = state.copyWith(todos: todos, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: _extractError(e));
+    } catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: e.toString());
+    }
+  }
+
+  Future<Todo?> createTodo(
+    String botId, {
+    required String title,
+    String? notes,
+    String? priority,
+    List<String>? tags,
+  }) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final todo = await service.createTodo(
+        botId,
+        title: title,
+        notes: notes,
+        priority: priority,
+        tags: tags,
+      );
+      state = state.copyWith(todos: [todo, ...state.todos]);
+      return todo;
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+      return null;
+    }
+  }
+
+  Future<void> completeTodo(String botId, String todoId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.completeTodo(botId, todoId);
+      state = state.copyWith(
+        todos: state.todos.map((t) => t.id == todoId ? updated : t).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> dismissTodo(String botId, String todoId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.dismissTodo(botId, todoId);
+      state = state.copyWith(
+        todos: state.todos.map((t) => t.id == todoId ? updated : t).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> deleteTodo(String botId, String todoId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      await service.deleteTodo(botId, todoId);
+      state = state.copyWith(
+        todos: state.todos.where((t) => t.id != todoId).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<BotWork?> convertToWork(
+    String botId,
+    String todoId, {
+    String? workTitle,
+    String? workDescription,
+  }) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final work = await service.convertTodoToWork(
+        botId,
+        todoId,
+        workTitle: workTitle,
+        workDescription: workDescription,
+      );
+      // Reload todos since the converted one changes status
+      await loadTodos(botId);
+      return work;
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+      return null;
+    }
+  }
+
+  void setFilter(TodoFilter filter) {
+    state = state.copyWith(filter: filter);
+  }
+
+  void clear() {
+    state = const TodosState();
+  }
+
+  String _extractError(DioException e) {
+    final data = e.response?.data;
+    if (data is Map<String, dynamic> && data.containsKey('detail')) {
+      final detail = data['detail'];
+      if (detail is String) return detail;
+      if (detail is Map) return detail['message']?.toString() ?? 'Request failed';
+    }
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.connectionError) {
+      return 'Cannot reach server';
+    }
+    return 'Request failed';
+  }
+}
+
+final todosProvider =
+    StateNotifierProvider<TodosNotifier, TodosState>((ref) {
+  return TodosNotifier(ref);
+});

--- a/mobile/lib/providers/work_provider.dart
+++ b/mobile/lib/providers/work_provider.dart
@@ -1,0 +1,177 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/work.dart';
+import 'service_providers.dart';
+
+enum WorkFilter { all, active, completed, failed }
+
+class WorkState {
+  const WorkState({
+    this.workItems = const [],
+    this.isLoading = false,
+    this.errorMessage,
+    this.isOffline = false,
+    this.filter = WorkFilter.all,
+  });
+
+  final List<BotWork> workItems;
+  final bool isLoading;
+  final String? errorMessage;
+  final bool isOffline;
+  final WorkFilter filter;
+
+  WorkState copyWith({
+    List<BotWork>? workItems,
+    bool? isLoading,
+    String? errorMessage,
+    bool clearError = false,
+    bool? isOffline,
+    WorkFilter? filter,
+  }) {
+    return WorkState(
+      workItems: workItems ?? this.workItems,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      isOffline: isOffline ?? this.isOffline,
+      filter: filter ?? this.filter,
+    );
+  }
+
+  List<BotWork> get filteredItems {
+    switch (filter) {
+      case WorkFilter.all:
+        return workItems;
+      case WorkFilter.active:
+        return workItems.where((w) => w.isActive).toList();
+      case WorkFilter.completed:
+        return workItems.where((w) => w.isDone).toList();
+      case WorkFilter.failed:
+        return workItems.where((w) => w.hasFailed).toList();
+    }
+  }
+}
+
+class WorkNotifier extends StateNotifier<WorkState> {
+  WorkNotifier(this._ref) : super(const WorkState());
+
+  final Ref _ref;
+
+  Future<void> loadWork(String botId) async {
+    state = state.copyWith(isLoading: true, clearError: true);
+    try {
+      final service = _ref.read(workServiceProvider);
+      final items = await service.listWork(botId);
+      state = state.copyWith(workItems: items, isLoading: false, isOffline: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: _extractError(e),
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, errorMessage: e.toString());
+    }
+  }
+
+  Future<BotWork?> createWork(
+    String botId, {
+    required String title,
+    String? description,
+    String? goal,
+    String? priority,
+    List<String>? tags,
+  }) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final work = await service.createWork(
+        botId,
+        title: title,
+        description: description,
+        goal: goal,
+        priority: priority,
+        tags: tags,
+      );
+      state = state.copyWith(workItems: [work, ...state.workItems]);
+      return work;
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+      return null;
+    }
+  }
+
+  Future<void> deleteWork(String botId, String workId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      await service.deleteWork(botId, workId);
+      state = state.copyWith(
+        workItems: state.workItems.where((w) => w.id != workId).toList(),
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> startWork(String botId, String workId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.startWork(botId, workId);
+      _replaceWork(updated);
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> completeWork(String botId, String workId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.completeWork(botId, workId);
+      _replaceWork(updated);
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  Future<void> cancelWork(String botId, String workId) async {
+    try {
+      final service = _ref.read(workServiceProvider);
+      final updated = await service.cancelWork(botId, workId);
+      _replaceWork(updated);
+    } on DioException catch (e) {
+      state = state.copyWith(errorMessage: _extractError(e));
+    }
+  }
+
+  void setFilter(WorkFilter filter) {
+    state = state.copyWith(filter: filter);
+  }
+
+  void clearError() {
+    state = state.copyWith(clearError: true);
+  }
+
+  void _replaceWork(BotWork updated) {
+    state = state.copyWith(
+      workItems:
+          state.workItems.map((w) => w.id == updated.id ? updated : w).toList(),
+    );
+  }
+
+  String _extractError(DioException e) {
+    final data = e.response?.data;
+    if (data is Map<String, dynamic> && data.containsKey('detail')) {
+      final detail = data['detail'];
+      if (detail is String) return detail;
+      if (detail is Map) return detail['message']?.toString() ?? 'Request failed';
+    }
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.connectionError) {
+      return 'Cannot reach server';
+    }
+    return 'Request failed';
+  }
+}
+
+final workProvider =
+    StateNotifierProvider<WorkNotifier, WorkState>((ref) {
+  return WorkNotifier(ref);
+});

--- a/mobile/lib/screens/bot/bot_detail_screen.dart
+++ b/mobile/lib/screens/bot/bot_detail_screen.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../models/bot.dart';
+import '../../providers/bots_provider.dart';
+import '../chat/chat_list_screen.dart';
+import '../knowledge/knowledge_list_screen.dart';
+import '../work/work_list_screen.dart';
+
+class BotDetailScreen extends ConsumerStatefulWidget {
+  const BotDetailScreen({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<BotDetailScreen> createState() => _BotDetailScreenState();
+}
+
+class _BotDetailScreenState extends ConsumerState<BotDetailScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  Bot? _findBot(BotsState state) {
+    return state.bots.where((b) => b.id == widget.botId).firstOrNull;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final botsState = ref.watch(botsProvider);
+    final bot = _findBot(botsState);
+
+    Color? botColor;
+    if (bot?.color != null && bot!.color!.isNotEmpty) {
+      try {
+        final hex = bot.color!.replaceFirst('#', '');
+        botColor = Color(int.parse('FF$hex', radix: 16));
+      } catch (_) {}
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/'),
+        ),
+        title: Row(
+          children: [
+            if (bot != null) ...[
+              Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: (botColor ?? theme.colorScheme.primary)
+                      .withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Center(
+                  child: bot.icon != null && bot.icon!.isNotEmpty
+                      ? Text(bot.icon!, style: const TextStyle(fontSize: 18))
+                      : Icon(
+                          Icons.smart_toy,
+                          size: 18,
+                          color: botColor ?? theme.colorScheme.primary,
+                        ),
+                ),
+              ),
+              const SizedBox(width: 10),
+            ],
+            Expanded(
+              child: Text(
+                bot?.name ?? 'Bot',
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Chats', icon: Icon(Icons.chat_bubble_outline, size: 20)),
+            Tab(text: 'Knowledge', icon: Icon(Icons.auto_stories_outlined, size: 20)),
+            Tab(text: 'Work', icon: Icon(Icons.work_outline, size: 20)),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          ChatListTab(botId: widget.botId),
+          KnowledgeListScreen(botId: widget.botId),
+          WorkListScreen(botId: widget.botId),
+        ],
+      ),
+    );
+  }
+}
+
+/// Chat list embedded as a tab (no Scaffold/AppBar).
+class ChatListTab extends ConsumerStatefulWidget {
+  const ChatListTab({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<ChatListTab> createState() => _ChatListTabState();
+}
+
+class _ChatListTabState extends ConsumerState<ChatListTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ChatListContent(botId: widget.botId);
+  }
+}

--- a/mobile/lib/screens/chat/chat_list_screen.dart
+++ b/mobile/lib/screens/chat/chat_list_screen.dart
@@ -6,6 +6,7 @@ import '../../core/utils/time_utils.dart';
 import '../../models/chat.dart';
 import '../../providers/chats_provider.dart';
 
+/// Standalone screen with its own Scaffold/AppBar (used for direct routes).
 class ChatListScreen extends ConsumerStatefulWidget {
   const ChatListScreen({required this.botId, super.key});
 
@@ -16,6 +17,41 @@ class ChatListScreen extends ConsumerStatefulWidget {
 }
 
 class _ChatListScreenState extends ConsumerState<ChatListScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(
+      () => ref.read(chatsProvider.notifier).loadChats(widget.botId),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chats'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.go('/chat/${widget.botId}'),
+        child: const Icon(Icons.add),
+      ),
+      body: ChatListContent(botId: widget.botId),
+    );
+  }
+}
+
+/// Reusable chat list body — used both in ChatListScreen and as a tab
+/// inside BotDetailScreen.
+class ChatListContent extends ConsumerStatefulWidget {
+  const ChatListContent({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<ChatListContent> createState() => _ChatListContentState();
+}
+
+class _ChatListContentState extends ConsumerState<ChatListContent> {
   @override
   void initState() {
     super.initState();
@@ -105,15 +141,19 @@ class _ChatListScreenState extends ConsumerState<ChatListScreen> {
     final theme = Theme.of(context);
     final state = ref.watch(chatsProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Chats'),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.go('/chat/${widget.botId}'),
-        child: const Icon(Icons.add),
-      ),
-      body: _buildBody(theme, state),
+    return Stack(
+      children: [
+        _buildBody(theme, state),
+        Positioned(
+          right: 16,
+          bottom: 16,
+          child: FloatingActionButton(
+            heroTag: 'newChat_${widget.botId}',
+            onPressed: () => context.go('/chat/${widget.botId}'),
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ],
     );
   }
 

--- a/mobile/lib/screens/chat/chat_screen.dart
+++ b/mobile/lib/screens/chat/chat_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
 
 import '../../models/chat.dart';
 import '../../providers/chat_provider.dart';
@@ -25,6 +26,10 @@ class ChatScreen extends ConsumerStatefulWidget {
 class _ChatScreenState extends ConsumerState<ChatScreen> {
   final _inputController = TextEditingController();
   final _scrollController = ScrollController();
+  final stt.SpeechToText _speech = stt.SpeechToText();
+  bool _isListening = false;
+  bool _speechAvailable = false;
+  String? _sharedText;
 
   @override
   void initState() {
@@ -32,10 +37,27 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     Future.microtask(() {
       ref.read(chatProvider.notifier).openChat(widget.botId, widget.chatId);
     });
+    _initSpeech();
+
+    // Handle shared text if passed via extra
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_sharedText != null && _sharedText!.isNotEmpty) {
+        _inputController.text = _sharedText!;
+        _sharedText = null;
+      }
+    });
+  }
+
+  Future<void> _initSpeech() async {
+    try {
+      _speechAvailable = await _speech.initialize();
+      if (mounted) setState(() {});
+    } catch (_) {}
   }
 
   @override
   void dispose() {
+    _speech.stop();
     _inputController.dispose();
     _scrollController.dispose();
     super.dispose();
@@ -48,6 +70,29 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     ref.read(chatProvider.notifier).sendMessage(text);
     _inputController.clear();
     _scrollToBottom();
+  }
+
+  void _toggleListening() async {
+    if (_isListening) {
+      await _speech.stop();
+      setState(() => _isListening = false);
+    } else {
+      setState(() => _isListening = true);
+      await _speech.listen(
+        onResult: (result) {
+          setState(() {
+            _inputController.text = result.recognizedWords;
+            _inputController.selection = TextSelection.fromPosition(
+              TextPosition(offset: _inputController.text.length),
+            );
+          });
+          if (result.finalResult) {
+            setState(() => _isListening = false);
+          }
+        },
+        listenMode: stt.ListenMode.dictation,
+      );
+    }
   }
 
   void _scrollToBottom() {
@@ -124,8 +169,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           _ChatInput(
             controller: _inputController,
             isLoading: state.isLoading,
+            isListening: _isListening,
+            speechAvailable: _speechAvailable,
             onSend: _sendMessage,
             onCancel: () => ref.read(chatProvider.notifier).cancelRequest(),
+            onMicPressed: _toggleListening,
           ),
         ],
       ),
@@ -323,14 +371,20 @@ class _ChatInput extends StatelessWidget {
   const _ChatInput({
     required this.controller,
     required this.isLoading,
+    required this.isListening,
+    required this.speechAvailable,
     required this.onSend,
     required this.onCancel,
+    required this.onMicPressed,
   });
 
   final TextEditingController controller;
   final bool isLoading;
+  final bool isListening;
+  final bool speechAvailable;
   final VoidCallback onSend;
   final VoidCallback onCancel;
+  final VoidCallback onMicPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -347,11 +401,24 @@ class _ChatInput extends StatelessWidget {
         top: false,
         child: Row(
           children: [
+            // Mic button
+            if (speechAvailable && !isLoading)
+              IconButton(
+                onPressed: onMicPressed,
+                icon: Icon(
+                  isListening ? Icons.mic : Icons.mic_none,
+                  color: isListening
+                      ? theme.colorScheme.error
+                      : theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
             Expanded(
               child: TextField(
                 controller: controller,
                 decoration: InputDecoration(
-                  hintText: 'Type a message...',
+                  hintText: isListening
+                      ? 'Listening...'
+                      : 'Type a message...',
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(24),
                   ),

--- a/mobile/lib/screens/chat/chat_screen.dart
+++ b/mobile/lib/screens/chat/chat_screen.dart
@@ -90,7 +90,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             setState(() => _isListening = false);
           }
         },
-        listenMode: stt.ListenMode.dictation,
+        listenOptions: stt.SpeechListenOptions(
+          listenMode: stt.ListenMode.dictation,
+        ),
       );
     }
   }

--- a/mobile/lib/screens/knowledge/knowledge_list_screen.dart
+++ b/mobile/lib/screens/knowledge/knowledge_list_screen.dart
@@ -1,0 +1,643 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/utils/time_utils.dart';
+import '../../models/knowledge.dart';
+import '../../providers/knowledge_provider.dart';
+
+class KnowledgeListScreen extends ConsumerStatefulWidget {
+  const KnowledgeListScreen({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<KnowledgeListScreen> createState() =>
+      _KnowledgeListScreenState();
+}
+
+class _KnowledgeListScreenState extends ConsumerState<KnowledgeListScreen>
+    with AutomaticKeepAliveClientMixin {
+  bool _showDocuments = false;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(
+      () => ref.read(knowledgeProvider.notifier).loadAll(widget.botId),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final theme = Theme.of(context);
+    final state = ref.watch(knowledgeProvider);
+
+    return Stack(
+      children: [
+        Column(
+          children: [
+            // Stats card
+            if (state.stats != null) _StatsBar(stats: state.stats!),
+
+            // Toggle: Notes / Documents
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SegmentedButton<bool>(
+                      segments: [
+                        ButtonSegment(
+                          value: false,
+                          label: Text('Notes (${state.notes.length})'),
+                          icon: const Icon(Icons.note_outlined, size: 18),
+                        ),
+                        ButtonSegment(
+                          value: true,
+                          label: Text('Docs (${state.documents.length})'),
+                          icon: const Icon(Icons.description_outlined, size: 18),
+                        ),
+                      ],
+                      selected: {_showDocuments},
+                      onSelectionChanged: (v) =>
+                          setState(() => _showDocuments = v.first),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton(
+                    icon: const Icon(Icons.search),
+                    onPressed: () => context.push(
+                      '/bot/${widget.botId}/knowledge/search',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Content
+            Expanded(
+              child: _buildContent(theme, state),
+            ),
+          ],
+        ),
+
+        // FAB
+        Positioned(
+          right: 16,
+          bottom: 16,
+          child: _buildFab(context),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFab(BuildContext context) {
+    return FloatingActionButton(
+      heroTag: 'knowledge_${widget.botId}',
+      onPressed: () {
+        if (_showDocuments) {
+          _showUploadSheet();
+        } else {
+          context.push('/bot/${widget.botId}/knowledge/new');
+        }
+      },
+      child: const Icon(Icons.add),
+    );
+  }
+
+  void _showUploadSheet() {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.note_add_outlined),
+              title: const Text('New Note'),
+              onTap: () {
+                Navigator.of(context).pop();
+                this.context.push('/bot/${widget.botId}/knowledge/new');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.upload_file),
+              title: const Text('Upload Document'),
+              subtitle: const Text('PDF, TXT, MD, DOCX up to 10MB'),
+              onTap: () {
+                Navigator.of(context).pop();
+                _pickAndUploadDocument();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickAndUploadDocument() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['pdf', 'txt', 'md', 'docx'],
+        withData: false,
+      );
+
+      if (result == null || result.files.isEmpty) return;
+      final file = result.files.first;
+      if (file.path == null) return;
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Uploading ${file.name}...')),
+        );
+      }
+
+      await ref.read(knowledgeProvider.notifier).uploadDocument(
+            widget.botId,
+            file.path!,
+            file.name,
+          );
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Document uploaded')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Upload failed: $e')),
+        );
+      }
+    }
+  }
+
+  Widget _buildContent(ThemeData theme, KnowledgeState state) {
+    if (state.isLoading && state.notes.isEmpty && state.documents.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.errorMessage != null &&
+        state.notes.isEmpty &&
+        state.documents.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline,
+                  size: 48, color: theme.colorScheme.error),
+              const SizedBox(height: 16),
+              Text(
+                state.errorMessage!,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: () => ref
+                    .read(knowledgeProvider.notifier)
+                    .loadAll(widget.botId),
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_showDocuments) {
+      return _buildDocumentsList(theme, state);
+    } else {
+      return _buildNotesList(theme, state);
+    }
+  }
+
+  Widget _buildNotesList(ThemeData theme, KnowledgeState state) {
+    if (state.notes.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.note_outlined,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+            const SizedBox(height: 16),
+            Text(
+              'No notes yet',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(knowledgeProvider.notifier).loadAll(widget.botId),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        itemCount: state.notes.length,
+        itemBuilder: (context, index) {
+          final note = state.notes[index];
+          return _NoteCard(
+            note: note,
+            onTap: () => context.push(
+              '/bot/${widget.botId}/knowledge/${note.id}',
+            ),
+            onDelete: () => _confirmDeleteNote(note),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildDocumentsList(ThemeData theme, KnowledgeState state) {
+    if (state.documents.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.description_outlined,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+            const SizedBox(height: 16),
+            Text(
+              'No documents uploaded',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(knowledgeProvider.notifier).loadDocuments(widget.botId),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        itemCount: state.documents.length,
+        itemBuilder: (context, index) {
+          final doc = state.documents[index];
+          return _DocumentCard(
+            document: doc,
+            onDelete: () => _confirmDeleteDocument(doc),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirmDeleteNote(BotNote note) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Note'),
+        content: Text('Delete "${note.title}"? This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      ref.read(knowledgeProvider.notifier).deleteNote(widget.botId, note.id);
+    }
+  }
+
+  Future<void> _confirmDeleteDocument(KnowledgeDocument doc) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Document'),
+        content: Text('Delete "${doc.filename}"? This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      ref
+          .read(knowledgeProvider.notifier)
+          .deleteDocument(widget.botId, doc.id);
+    }
+  }
+}
+
+class _StatsBar extends StatelessWidget {
+  const _StatsBar({required this.stats});
+
+  final KnowledgeStats stats;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          _StatItem(
+            label: 'Notes',
+            value: stats.totalNotes.toString(),
+            icon: Icons.note_outlined,
+          ),
+          _StatItem(
+            label: 'Docs',
+            value: stats.totalDocuments.toString(),
+            icon: Icons.description_outlined,
+          ),
+          _StatItem(
+            label: 'Chunks',
+            value: stats.totalChunks.toString(),
+            icon: Icons.data_array,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatItem extends StatelessWidget {
+  const _StatItem({
+    required this.label,
+    required this.value,
+    required this.icon,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 18, color: theme.colorScheme.primary),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NoteCard extends StatelessWidget {
+  const _NoteCard({
+    required this.note,
+    required this.onTap,
+    required this.onDelete,
+  });
+
+  final BotNote note;
+  final VoidCallback onTap;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Dismissible(
+      key: ValueKey(note.id),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.error,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(Icons.delete, color: theme.colorScheme.onError),
+      ),
+      confirmDismiss: (_) async {
+        onDelete();
+        return false;
+      },
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          title: Text(
+            note.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.titleSmall
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (note.tags.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Wrap(
+                    spacing: 4,
+                    children: note.tags
+                        .take(3)
+                        .map((tag) => Chip(
+                              label: Text(tag),
+                              labelStyle: theme.textTheme.bodySmall,
+                              materialTapTargetSize:
+                                  MaterialTapTargetSize.shrinkWrap,
+                              visualDensity: VisualDensity.compact,
+                              padding: EdgeInsets.zero,
+                            ))
+                        .toList(),
+                  ),
+                ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  Text(
+                    formatRelativeTime(note.updatedAt),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface
+                          .withValues(alpha: 0.5),
+                    ),
+                  ),
+                  if (note.source == 'bot') ...[
+                    const SizedBox(width: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 1),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primaryContainer,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Text(
+                        'bot',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontSize: 10,
+                          color: theme.colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ],
+          ),
+          trailing: Icon(
+            Icons.chevron_right,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
+          ),
+          onTap: onTap,
+        ),
+      ),
+    );
+  }
+}
+
+class _DocumentCard extends StatelessWidget {
+  const _DocumentCard({
+    required this.document,
+    required this.onDelete,
+  });
+
+  final KnowledgeDocument document;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    Color statusColor;
+    IconData statusIcon;
+    switch (document.status) {
+      case 'ready':
+        statusColor = Colors.green;
+        statusIcon = Icons.check_circle_outline;
+      case 'processing':
+        statusColor = Colors.orange;
+        statusIcon = Icons.hourglass_top;
+      case 'failed':
+        statusColor = theme.colorScheme.error;
+        statusIcon = Icons.error_outline;
+      default:
+        statusColor = Colors.grey;
+        statusIcon = Icons.help_outline;
+    }
+
+    return Dismissible(
+      key: ValueKey(document.id),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.error,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(Icons.delete, color: theme.colorScheme.onError),
+      ),
+      confirmDismiss: (_) async {
+        onDelete();
+        return false;
+      },
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          leading: Icon(
+            _fileTypeIcon(document.fileType),
+            color: theme.colorScheme.primary,
+          ),
+          title: Text(
+            document.filename,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.titleSmall
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          subtitle: Row(
+            children: [
+              Icon(statusIcon, size: 14, color: statusColor),
+              const SizedBox(width: 4),
+              Text(
+                document.status,
+                style: theme.textTheme.bodySmall?.copyWith(color: statusColor),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                '${document.chunkCount} chunks',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                ),
+              ),
+            ],
+          ),
+          trailing: Icon(
+            Icons.chevron_right,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _fileTypeIcon(String fileType) {
+    switch (fileType.toLowerCase()) {
+      case 'pdf':
+        return Icons.picture_as_pdf;
+      case 'md':
+      case 'markdown':
+        return Icons.article_outlined;
+      case 'txt':
+        return Icons.text_snippet_outlined;
+      case 'docx':
+      case 'doc':
+        return Icons.description_outlined;
+      default:
+        return Icons.insert_drive_file_outlined;
+    }
+  }
+}

--- a/mobile/lib/screens/knowledge/knowledge_search_screen.dart
+++ b/mobile/lib/screens/knowledge/knowledge_search_screen.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../models/knowledge.dart';
+import '../../providers/knowledge_provider.dart';
+
+class KnowledgeSearchScreen extends ConsumerStatefulWidget {
+  const KnowledgeSearchScreen({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<KnowledgeSearchScreen> createState() =>
+      _KnowledgeSearchScreenState();
+}
+
+class _KnowledgeSearchScreenState
+    extends ConsumerState<KnowledgeSearchScreen> {
+  final _searchController = TextEditingController();
+  Timer? _debounce;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String query) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), () {
+      ref.read(knowledgeProvider.notifier).search(widget.botId, query);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(knowledgeProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: TextField(
+          controller: _searchController,
+          autofocus: true,
+          decoration: const InputDecoration(
+            hintText: 'Search knowledge base...',
+            border: InputBorder.none,
+          ),
+          onChanged: _onSearchChanged,
+        ),
+        actions: [
+          if (_searchController.text.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _searchController.clear();
+                ref.read(knowledgeProvider.notifier).search(widget.botId, '');
+              },
+            ),
+        ],
+      ),
+      body: _buildResults(theme, state),
+    );
+  }
+
+  Widget _buildResults(ThemeData theme, KnowledgeState state) {
+    if (state.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.searchQuery.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+            const SizedBox(height: 16),
+            Text(
+              'Search notes and documents',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (state.searchResults.isEmpty) {
+      return Center(
+        child: Text(
+          'No results for "${state.searchQuery}"',
+          style: theme.textTheme.bodyLarge?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+          ),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      itemCount: state.searchResults.length,
+      itemBuilder: (context, index) {
+        final result = state.searchResults[index];
+        return _SearchResultCard(
+          result: result,
+          onTap: () {
+            if (result.type == 'note') {
+              context.push(
+                '/bot/${widget.botId}/knowledge/${result.id}',
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+}
+
+class _SearchResultCard extends StatelessWidget {
+  const _SearchResultCard({required this.result, required this.onTap});
+
+  final SearchResult result;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isNote = result.type == 'note';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        leading: Icon(
+          isNote ? Icons.note_outlined : Icons.description_outlined,
+          color: theme.colorScheme.primary,
+        ),
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(
+                result.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ),
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: isNote
+                    ? theme.colorScheme.primaryContainer
+                    : theme.colorScheme.secondaryContainer,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                result.type,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontSize: 10,
+                  color: isNote
+                      ? theme.colorScheme.onPrimaryContainer
+                      : theme.colorScheme.onSecondaryContainer,
+                ),
+              ),
+            ),
+          ],
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 4),
+            Text(
+              result.content,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+            if (result.score != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  'Relevance: ${(result.score! * 100).toStringAsFixed(0)}%',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontSize: 10,
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                  ),
+                ),
+              ),
+          ],
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/knowledge/note_editor_screen.dart
+++ b/mobile/lib/screens/knowledge/note_editor_screen.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../models/knowledge.dart';
+import '../../providers/knowledge_provider.dart';
+
+class NoteEditorScreen extends ConsumerStatefulWidget {
+  const NoteEditorScreen({
+    required this.botId,
+    this.noteId,
+    super.key,
+  });
+
+  final String botId;
+  final String? noteId;
+
+  bool get isEditing => noteId != null;
+
+  @override
+  ConsumerState<NoteEditorScreen> createState() => _NoteEditorScreenState();
+}
+
+class _NoteEditorScreenState extends ConsumerState<NoteEditorScreen> {
+  final _titleController = TextEditingController();
+  final _contentController = TextEditingController();
+  final _tagController = TextEditingController();
+  final List<String> _tags = [];
+  bool _isLoading = false;
+  BotNote? _existingNote;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.isEditing) {
+      _loadNote();
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    _tagController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadNote() async {
+    final knowledgeState = ref.read(knowledgeProvider);
+    final note =
+        knowledgeState.notes.where((n) => n.id == widget.noteId).firstOrNull;
+    if (note != null) {
+      _existingNote = note;
+      _titleController.text = note.title;
+      _contentController.text = note.content;
+      _tags.addAll(note.tags);
+      setState(() {});
+    }
+  }
+
+  void _addTag() {
+    final tag = _tagController.text.trim();
+    if (tag.isNotEmpty && !_tags.contains(tag)) {
+      setState(() => _tags.add(tag));
+      _tagController.clear();
+    }
+  }
+
+  void _removeTag(String tag) {
+    setState(() => _tags.remove(tag));
+  }
+
+  Future<void> _save() async {
+    final title = _titleController.text.trim();
+    final content = _contentController.text.trim();
+
+    if (title.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Title is required')),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    final notifier = ref.read(knowledgeProvider.notifier);
+
+    if (widget.isEditing) {
+      final result = await notifier.updateNote(
+        widget.botId,
+        widget.noteId!,
+        title: title,
+        content: content,
+        tags: _tags,
+      );
+      if (result != null && mounted) context.pop();
+    } else {
+      final result = await notifier.createNote(
+        widget.botId,
+        title: title,
+        content: content,
+        tags: _tags,
+      );
+      if (result != null && mounted) context.pop();
+    }
+
+    if (mounted) setState(() => _isLoading = false);
+  }
+
+  Future<void> _delete() async {
+    if (!widget.isEditing) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Note'),
+        content: Text(
+          'Delete "${_existingNote?.title ?? 'this note'}"? This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await ref
+          .read(knowledgeProvider.notifier)
+          .deleteNote(widget.botId, widget.noteId!);
+      if (mounted) context.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.isEditing ? 'Edit Note' : 'New Note'),
+        actions: [
+          if (widget.isEditing)
+            IconButton(
+              icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+              onPressed: _delete,
+            ),
+          IconButton(
+            icon: _isLoading
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.check),
+            onPressed: _isLoading ? null : _save,
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Title
+          TextField(
+            controller: _titleController,
+            decoration: const InputDecoration(
+              labelText: 'Title',
+              border: OutlineInputBorder(),
+            ),
+            textInputAction: TextInputAction.next,
+            maxLength: 200,
+          ),
+          const SizedBox(height: 16),
+
+          // Content
+          TextField(
+            controller: _contentController,
+            decoration: const InputDecoration(
+              labelText: 'Content',
+              border: OutlineInputBorder(),
+              alignLabelWithHint: true,
+            ),
+            maxLines: 12,
+            minLines: 6,
+            textInputAction: TextInputAction.newline,
+          ),
+          const SizedBox(height: 16),
+
+          // Tags
+          Text('Tags', style: theme.textTheme.titleSmall),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _tagController,
+                  decoration: const InputDecoration(
+                    hintText: 'Add a tag',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  onSubmitted: (_) => _addTag(),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton.filled(
+                onPressed: _addTag,
+                icon: const Icon(Icons.add),
+              ),
+            ],
+          ),
+          if (_tags.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: _tags
+                    .map(
+                      (tag) => Chip(
+                        label: Text(tag),
+                        onDeleted: () => _removeTag(tag),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/work/todos_screen.dart
+++ b/mobile/lib/screens/work/todos_screen.dart
@@ -422,7 +422,7 @@ class _TodoCard extends StatelessWidget {
                     ),
                     if (todo.remindAt != null) ...[
                       const SizedBox(width: 8),
-                      Icon(Icons.alarm, size: 12, color: Colors.orange),
+                      const Icon(Icons.alarm, size: 12, color: Colors.orange),
                       const SizedBox(width: 2),
                       Text(
                         formatRelativeTime(todo.remindAt!),

--- a/mobile/lib/screens/work/todos_screen.dart
+++ b/mobile/lib/screens/work/todos_screen.dart
@@ -1,0 +1,445 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/utils/time_utils.dart';
+import '../../models/work.dart';
+import '../../providers/todos_provider.dart';
+
+class TodosScreen extends ConsumerStatefulWidget {
+  const TodosScreen({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<TodosScreen> createState() => _TodosScreenState();
+}
+
+class _TodosScreenState extends ConsumerState<TodosScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(
+      () => ref.read(todosProvider.notifier).loadTodos(widget.botId),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(todosProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Todos'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showCreateDialog(context),
+        child: const Icon(Icons.add),
+      ),
+      body: Column(
+        children: [
+          // Filter chips
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: TodoFilter.values.map((filter) {
+                final isSelected = state.filter == filter;
+                return Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: FilterChip(
+                    label: Text(_filterLabel(filter)),
+                    selected: isSelected,
+                    onSelected: (_) =>
+                        ref.read(todosProvider.notifier).setFilter(filter),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+
+          // Content
+          Expanded(child: _buildContent(theme, state)),
+        ],
+      ),
+    );
+  }
+
+  String _filterLabel(TodoFilter filter) {
+    switch (filter) {
+      case TodoFilter.open:
+        return 'Open';
+      case TodoFilter.done:
+        return 'Done';
+      case TodoFilter.all:
+        return 'All';
+    }
+  }
+
+  Widget _buildContent(ThemeData theme, TodosState state) {
+    if (state.isLoading && state.todos.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.errorMessage != null && state.todos.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline,
+                  size: 48, color: theme.colorScheme.error),
+              const SizedBox(height: 16),
+              Text(state.errorMessage!, textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: () =>
+                    ref.read(todosProvider.notifier).loadTodos(widget.botId),
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final items = state.filteredTodos;
+
+    if (items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.checklist,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+            const SizedBox(height: 16),
+            Text(
+              'No todos',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(todosProvider.notifier).loadTodos(widget.botId),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final todo = items[index];
+          return _TodoCard(
+            todo: todo,
+            onToggle: () {
+              if (todo.isOpen) {
+                ref
+                    .read(todosProvider.notifier)
+                    .completeTodo(widget.botId, todo.id);
+              }
+            },
+            onDismiss: () => ref
+                .read(todosProvider.notifier)
+                .dismissTodo(widget.botId, todo.id),
+            onDelete: () => _confirmDelete(todo),
+            onLongPress: () => _showContextMenu(todo),
+          );
+        },
+      ),
+    );
+  }
+
+  void _showContextMenu(Todo todo) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (todo.isOpen)
+              ListTile(
+                leading: const Icon(Icons.check_circle_outline),
+                title: const Text('Mark Done'),
+                onTap: () {
+                  Navigator.of(ctx).pop();
+                  ref
+                      .read(todosProvider.notifier)
+                      .completeTodo(widget.botId, todo.id);
+                },
+              ),
+            if (todo.isOpen)
+              ListTile(
+                leading: const Icon(Icons.do_not_disturb),
+                title: const Text('Dismiss'),
+                onTap: () {
+                  Navigator.of(ctx).pop();
+                  ref
+                      .read(todosProvider.notifier)
+                      .dismissTodo(widget.botId, todo.id);
+                },
+              ),
+            if (todo.isOpen)
+              ListTile(
+                leading: const Icon(Icons.work_outline),
+                title: const Text('Convert to Work'),
+                onTap: () {
+                  Navigator.of(ctx).pop();
+                  ref.read(todosProvider.notifier).convertToWork(
+                        widget.botId,
+                        todo.id,
+                        workTitle: todo.title,
+                      );
+                },
+              ),
+            ListTile(
+              leading: Icon(Icons.delete_outline,
+                  color: Theme.of(ctx).colorScheme.error),
+              title: Text('Delete',
+                  style: TextStyle(color: Theme.of(ctx).colorScheme.error)),
+              onTap: () {
+                Navigator.of(ctx).pop();
+                _confirmDelete(todo);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(Todo todo) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Todo'),
+        content: Text('Delete "${todo.title}"? This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      ref.read(todosProvider.notifier).deleteTodo(widget.botId, todo.id);
+    }
+  }
+
+  Future<void> _showCreateDialog(BuildContext context) async {
+    final titleController = TextEditingController();
+    final notesController = TextEditingController();
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('New Todo'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: notesController,
+              decoration: const InputDecoration(
+                labelText: 'Notes (optional)',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 2,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true && mounted) {
+      final title = titleController.text.trim();
+      if (title.isNotEmpty) {
+        final notes = notesController.text.trim();
+        ref.read(todosProvider.notifier).createTodo(
+              widget.botId,
+              title: title,
+              notes: notes.isNotEmpty ? notes : null,
+            );
+      }
+    }
+
+    titleController.dispose();
+    notesController.dispose();
+  }
+}
+
+class _TodoCard extends StatelessWidget {
+  const _TodoCard({
+    required this.todo,
+    required this.onToggle,
+    required this.onDismiss,
+    required this.onDelete,
+    required this.onLongPress,
+  });
+
+  final Todo todo;
+  final VoidCallback onToggle;
+  final VoidCallback onDismiss;
+  final VoidCallback onDelete;
+  final VoidCallback onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    Color priorityColor;
+    switch (todo.priority) {
+      case Priority.urgent:
+        priorityColor = Colors.red;
+      case Priority.high:
+        priorityColor = Colors.orange;
+      case Priority.normal:
+        priorityColor = theme.colorScheme.primary;
+      case Priority.low:
+        priorityColor = Colors.grey;
+    }
+
+    return Dismissible(
+      key: ValueKey(todo.id),
+      background: Container(
+        alignment: Alignment.centerLeft,
+        padding: const EdgeInsets.only(left: 20),
+        decoration: BoxDecoration(
+          color: Colors.green,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Icon(Icons.check, color: Colors.white),
+      ),
+      secondaryBackground: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.error,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(Icons.delete, color: theme.colorScheme.onError),
+      ),
+      confirmDismiss: (direction) async {
+        if (direction == DismissDirection.startToEnd) {
+          onToggle();
+          return false;
+        } else {
+          onDelete();
+          return false;
+        }
+      },
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 6),
+        child: ListTile(
+          dense: true,
+          leading: Container(
+            width: 4,
+            height: 32,
+            decoration: BoxDecoration(
+              color: priorityColor,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          title: Row(
+            children: [
+              Checkbox(
+                value: todo.isDone,
+                onChanged: todo.isOpen ? (_) => onToggle() : null,
+                visualDensity: VisualDensity.compact,
+              ),
+              Expanded(
+                child: Text(
+                  todo.title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    decoration:
+                        todo.isDone ? TextDecoration.lineThrough : null,
+                    color: todo.isDone
+                        ? theme.colorScheme.onSurface.withValues(alpha: 0.5)
+                        : null,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (todo.notes != null)
+                Padding(
+                  padding: const EdgeInsets.only(left: 40),
+                  child: Text(
+                    todo.notes!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface
+                          .withValues(alpha: 0.6),
+                    ),
+                  ),
+                ),
+              Padding(
+                padding: const EdgeInsets.only(left: 40, top: 2),
+                child: Row(
+                  children: [
+                    Text(
+                      formatRelativeTime(todo.createdAt),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontSize: 10,
+                        color: theme.colorScheme.onSurface
+                            .withValues(alpha: 0.4),
+                      ),
+                    ),
+                    if (todo.remindAt != null) ...[
+                      const SizedBox(width: 8),
+                      Icon(Icons.alarm, size: 12, color: Colors.orange),
+                      const SizedBox(width: 2),
+                      Text(
+                        formatRelativeTime(todo.remindAt!),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontSize: 10,
+                          color: Colors.orange,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          onLongPress: onLongPress,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/work/work_detail_screen.dart
+++ b/mobile/lib/screens/work/work_detail_screen.dart
@@ -1,0 +1,572 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/utils/time_utils.dart';
+import '../../models/work.dart';
+import '../../providers/tasks_provider.dart';
+import '../../providers/work_provider.dart';
+
+class WorkDetailScreen extends ConsumerStatefulWidget {
+  const WorkDetailScreen({
+    required this.botId,
+    required this.workId,
+    super.key,
+  });
+
+  final String botId;
+  final String workId;
+
+  @override
+  ConsumerState<WorkDetailScreen> createState() => _WorkDetailScreenState();
+}
+
+class _WorkDetailScreenState extends ConsumerState<WorkDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      ref.read(tasksProvider.notifier).loadTasks(widget.botId, widget.workId);
+    });
+  }
+
+  BotWork? _findWork(WorkState state) {
+    return state.workItems.where((w) => w.id == widget.workId).firstOrNull;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final workState = ref.watch(workProvider);
+    final tasksState = ref.watch(tasksProvider);
+    final work = _findWork(workState);
+
+    if (work == null) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(work.title, overflow: TextOverflow.ellipsis),
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: (action) => _handleAction(action, work),
+            itemBuilder: (context) => [
+              if (work.status == WorkStatus.pending)
+                const PopupMenuItem(value: 'start', child: Text('Start')),
+              if (work.isActive)
+                const PopupMenuItem(
+                    value: 'complete', child: Text('Complete')),
+              if (work.isActive)
+                const PopupMenuItem(value: 'cancel', child: Text('Cancel')),
+              const PopupMenuItem(value: 'delete', child: Text('Delete')),
+            ],
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.small(
+        onPressed: () => _showAddTaskDialog(),
+        child: const Icon(Icons.add),
+      ),
+      body: RefreshIndicator(
+        onRefresh: () => ref
+            .read(tasksProvider.notifier)
+            .loadTasks(widget.botId, widget.workId),
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Header card
+            _WorkHeader(work: work),
+            const SizedBox(height: 16),
+
+            // Action buttons
+            _ActionButtons(
+              work: work,
+              onStart: () => ref
+                  .read(workProvider.notifier)
+                  .startWork(widget.botId, work.id),
+              onComplete: () => ref
+                  .read(workProvider.notifier)
+                  .completeWork(widget.botId, work.id),
+              onCancel: () => ref
+                  .read(workProvider.notifier)
+                  .cancelWork(widget.botId, work.id),
+            ),
+            const SizedBox(height: 16),
+
+            // Tasks section
+            Text('Tasks', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+
+            if (tasksState.isLoading && tasksState.tasks.isEmpty)
+              const Padding(
+                padding: EdgeInsets.all(32),
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else if (tasksState.tasks.isEmpty)
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: Text(
+                    'No tasks yet',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: theme.colorScheme.onSurface
+                          .withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              )
+            else
+              ...tasksState.tasks.map(
+                (task) => _TaskItem(
+                  task: task,
+                  botId: widget.botId,
+                ),
+              ),
+
+            // Tags
+            if (work.tags.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: work.tags
+                    .map((tag) => Chip(
+                          label: Text(tag),
+                          visualDensity: VisualDensity.compact,
+                        ))
+                    .toList(),
+              ),
+            ],
+
+            const SizedBox(height: 80),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _handleAction(String action, BotWork work) {
+    switch (action) {
+      case 'start':
+        ref.read(workProvider.notifier).startWork(widget.botId, work.id);
+      case 'complete':
+        ref.read(workProvider.notifier).completeWork(widget.botId, work.id);
+      case 'cancel':
+        ref.read(workProvider.notifier).cancelWork(widget.botId, work.id);
+      case 'delete':
+        _confirmDelete(work);
+    }
+  }
+
+  Future<void> _confirmDelete(BotWork work) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Work'),
+        content: Text('Delete "${work.title}"? This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      await ref
+          .read(workProvider.notifier)
+          .deleteWork(widget.botId, work.id);
+      if (mounted) context.pop();
+    }
+  }
+
+  Future<void> _showAddTaskDialog() async {
+    final titleController = TextEditingController();
+    final descController = TextEditingController();
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Add Task'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: descController,
+              decoration: const InputDecoration(
+                labelText: 'Description (optional)',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 2,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true && mounted) {
+      final title = titleController.text.trim();
+      if (title.isNotEmpty) {
+        final desc = descController.text.trim();
+        ref.read(tasksProvider.notifier).createTask(
+              widget.botId,
+              widget.workId,
+              title: title,
+              description: desc.isNotEmpty ? desc : null,
+            );
+      }
+    }
+
+    titleController.dispose();
+    descController.dispose();
+  }
+}
+
+class _WorkHeader extends StatelessWidget {
+  const _WorkHeader({required this.work});
+
+  final BotWork work;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Status + priority
+            Row(
+              children: [
+                _StatusChip(status: work.status),
+                const SizedBox(width: 8),
+                _PriorityChip(priority: work.priority),
+                const Spacer(),
+                Text(
+                  formatRelativeTime(work.createdAt),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                ),
+              ],
+            ),
+
+            // Description
+            if (work.description != null) ...[
+              const SizedBox(height: 12),
+              Text(work.description!, style: theme.textTheme.bodyMedium),
+            ],
+
+            // Goal
+            if (work.goal != null) ...[
+              const SizedBox(height: 8),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.flag_outlined,
+                      size: 16, color: theme.colorScheme.primary),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      work.goal!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+
+            // Progress
+            if (work.progress > 0 || work.isActive) ...[
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: work.progress,
+                        minHeight: 6,
+                        backgroundColor:
+                            theme.colorScheme.surfaceContainerHigh,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${(work.progress * 100).toInt()}%',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ],
+
+            // Error
+            if (work.error != null) ...[
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.errorContainer,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.error_outline,
+                        size: 16, color: theme.colorScheme.error),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        work.error!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onErrorContainer,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.status});
+
+  final WorkStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    Color color;
+    String label;
+    switch (status) {
+      case WorkStatus.pending:
+        color = Colors.grey;
+        label = 'Pending';
+      case WorkStatus.inProgress:
+        color = Colors.blue;
+        label = 'In Progress';
+      case WorkStatus.completed:
+        color = Colors.green;
+        label = 'Completed';
+      case WorkStatus.failed:
+        color = Theme.of(context).colorScheme.error;
+        label = 'Failed';
+      case WorkStatus.cancelled:
+        color = Colors.orange;
+        label = 'Cancelled';
+      case WorkStatus.paused:
+        color = Colors.amber;
+        label = 'Paused';
+    }
+
+    return Chip(
+      label: Text(label,
+          style: TextStyle(color: color, fontSize: 12)),
+      backgroundColor: color.withValues(alpha: 0.15),
+      side: BorderSide.none,
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+}
+
+class _PriorityChip extends StatelessWidget {
+  const _PriorityChip({required this.priority});
+
+  final Priority priority;
+
+  @override
+  Widget build(BuildContext context) {
+    if (priority == Priority.normal) return const SizedBox.shrink();
+
+    Color color;
+    String label;
+    switch (priority) {
+      case Priority.urgent:
+        color = Colors.red;
+        label = 'Urgent';
+      case Priority.high:
+        color = Colors.orange;
+        label = 'High';
+      case Priority.low:
+        color = Colors.grey;
+        label = 'Low';
+      case Priority.normal:
+        color = Colors.blue;
+        label = 'Normal';
+    }
+
+    return Chip(
+      avatar: Icon(Icons.flag, size: 14, color: color),
+      label: Text(label, style: TextStyle(color: color, fontSize: 12)),
+      backgroundColor: color.withValues(alpha: 0.1),
+      side: BorderSide.none,
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+}
+
+class _ActionButtons extends StatelessWidget {
+  const _ActionButtons({
+    required this.work,
+    required this.onStart,
+    required this.onComplete,
+    required this.onCancel,
+  });
+
+  final BotWork work;
+  final VoidCallback onStart;
+  final VoidCallback onComplete;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    if (work.isDone || work.status == WorkStatus.cancelled) {
+      return const SizedBox.shrink();
+    }
+
+    return Row(
+      children: [
+        if (work.status == WorkStatus.pending)
+          Expanded(
+            child: FilledButton.icon(
+              onPressed: onStart,
+              icon: const Icon(Icons.play_arrow, size: 18),
+              label: const Text('Start'),
+            ),
+          ),
+        if (work.isActive) ...[
+          Expanded(
+            child: FilledButton.icon(
+              onPressed: onComplete,
+              icon: const Icon(Icons.check, size: 18),
+              label: const Text('Complete'),
+            ),
+          ),
+          const SizedBox(width: 8),
+          OutlinedButton.icon(
+            onPressed: onCancel,
+            icon: const Icon(Icons.close, size: 18),
+            label: const Text('Cancel'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _TaskItem extends ConsumerWidget {
+  const _TaskItem({required this.task, required this.botId});
+
+  final WorkTask task;
+  final String botId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
+    IconData icon;
+    Color iconColor;
+    switch (task.status) {
+      case TaskStatus.completed:
+        icon = Icons.check_circle;
+        iconColor = Colors.green;
+      case TaskStatus.failed:
+        icon = Icons.error;
+        iconColor = theme.colorScheme.error;
+      case TaskStatus.inProgress:
+        icon = Icons.play_circle_filled;
+        iconColor = Colors.blue;
+      case TaskStatus.blocked:
+        icon = Icons.block;
+        iconColor = Colors.orange;
+      case TaskStatus.skipped:
+        icon = Icons.skip_next;
+        iconColor = Colors.grey;
+      default:
+        icon = Icons.radio_button_unchecked;
+        iconColor = Colors.grey;
+    }
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 6),
+      child: ListTile(
+        dense: true,
+        leading: Icon(icon, color: iconColor, size: 22),
+        title: Text(
+          task.title,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            decoration:
+                task.isDone ? TextDecoration.lineThrough : null,
+          ),
+        ),
+        subtitle: task.description != null
+            ? Text(
+                task.description!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              )
+            : null,
+        trailing: task.error != null
+            ? Tooltip(
+                message: task.error!,
+                child: Icon(Icons.warning_amber,
+                    size: 18, color: theme.colorScheme.error),
+              )
+            : null,
+        onTap: () {
+          if (task.status == TaskStatus.pending ||
+              task.status == TaskStatus.ready) {
+            ref
+                .read(tasksProvider.notifier)
+                .startTask(botId, task.id);
+          } else if (task.isRunning) {
+            ref
+                .read(tasksProvider.notifier)
+                .completeTask(botId, task.id);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/work/work_list_screen.dart
+++ b/mobile/lib/screens/work/work_list_screen.dart
@@ -1,0 +1,490 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/utils/time_utils.dart';
+import '../../models/work.dart';
+import '../../providers/work_provider.dart';
+
+class WorkListScreen extends ConsumerStatefulWidget {
+  const WorkListScreen({required this.botId, super.key});
+
+  final String botId;
+
+  @override
+  ConsumerState<WorkListScreen> createState() => _WorkListScreenState();
+}
+
+class _WorkListScreenState extends ConsumerState<WorkListScreen>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(
+      () => ref.read(workProvider.notifier).loadWork(widget.botId),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final theme = Theme.of(context);
+    final state = ref.watch(workProvider);
+
+    return Stack(
+      children: [
+        Column(
+          children: [
+            // Filter chips
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: WorkFilter.values.map((filter) {
+                  final isSelected = state.filter == filter;
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: FilterChip(
+                      label: Text(_filterLabel(filter)),
+                      selected: isSelected,
+                      onSelected: (_) =>
+                          ref.read(workProvider.notifier).setFilter(filter),
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+
+            // Content
+            Expanded(child: _buildContent(theme, state)),
+          ],
+        ),
+
+        // FAB
+        Positioned(
+          right: 16,
+          bottom: 16,
+          child: FloatingActionButton(
+            heroTag: 'work_${widget.botId}',
+            onPressed: () => _showCreateDialog(context),
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _filterLabel(WorkFilter filter) {
+    switch (filter) {
+      case WorkFilter.all:
+        return 'All';
+      case WorkFilter.active:
+        return 'Active';
+      case WorkFilter.completed:
+        return 'Completed';
+      case WorkFilter.failed:
+        return 'Failed';
+    }
+  }
+
+  Widget _buildContent(ThemeData theme, WorkState state) {
+    if (state.isLoading && state.workItems.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.errorMessage != null && state.workItems.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline,
+                  size: 48, color: theme.colorScheme.error),
+              const SizedBox(height: 16),
+              Text(state.errorMessage!, textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: () =>
+                    ref.read(workProvider.notifier).loadWork(widget.botId),
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final items = state.filteredItems;
+
+    if (items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.work_outline,
+                size: 64,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3)),
+            const SizedBox(height: 16),
+            Text(
+              state.filter == WorkFilter.all
+                  ? 'No work items'
+                  : 'No ${_filterLabel(state.filter).toLowerCase()} items',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => ref.read(workProvider.notifier).loadWork(widget.botId),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final work = items[index];
+          return _WorkCard(
+            work: work,
+            onTap: () => context.push('/bot/${widget.botId}/work/${work.id}'),
+            onLongPress: () => _showContextMenu(work),
+          );
+        },
+      ),
+    );
+  }
+
+  void _showContextMenu(BotWork work) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (work.status == WorkStatus.pending)
+              ListTile(
+                leading: const Icon(Icons.play_arrow),
+                title: const Text('Start'),
+                onTap: () {
+                  Navigator.of(ctx).pop();
+                  ref
+                      .read(workProvider.notifier)
+                      .startWork(widget.botId, work.id);
+                },
+              ),
+            if (work.isActive)
+              ListTile(
+                leading: const Icon(Icons.check_circle_outline),
+                title: const Text('Complete'),
+                onTap: () {
+                  Navigator.of(ctx).pop();
+                  ref
+                      .read(workProvider.notifier)
+                      .completeWork(widget.botId, work.id);
+                },
+              ),
+            if (work.isActive)
+              ListTile(
+                leading: const Icon(Icons.cancel_outlined),
+                title: const Text('Cancel'),
+                onTap: () {
+                  Navigator.of(ctx).pop();
+                  ref
+                      .read(workProvider.notifier)
+                      .cancelWork(widget.botId, work.id);
+                },
+              ),
+            ListTile(
+              leading: Icon(Icons.delete_outline,
+                  color: Theme.of(ctx).colorScheme.error),
+              title: Text('Delete',
+                  style: TextStyle(color: Theme.of(ctx).colorScheme.error)),
+              onTap: () {
+                Navigator.of(ctx).pop();
+                _confirmDelete(work);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(BotWork work) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Work'),
+        content: Text('Delete "${work.title}"? This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      ref.read(workProvider.notifier).deleteWork(widget.botId, work.id);
+    }
+  }
+
+  Future<void> _showCreateDialog(BuildContext context) async {
+    final titleController = TextEditingController();
+    final descriptionController = TextEditingController();
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Create Work'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Description (optional)',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true && mounted) {
+      final title = titleController.text.trim();
+      if (title.isNotEmpty) {
+        final desc = descriptionController.text.trim();
+        ref.read(workProvider.notifier).createWork(
+              widget.botId,
+              title: title,
+              description: desc.isNotEmpty ? desc : null,
+            );
+      }
+    }
+
+    titleController.dispose();
+    descriptionController.dispose();
+  }
+}
+
+class _WorkCard extends StatelessWidget {
+  const _WorkCard({
+    required this.work,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  final BotWork work;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Title row
+              Row(
+                children: [
+                  _PriorityIndicator(priority: work.priority),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      work.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  _StatusBadge(status: work.status),
+                ],
+              ),
+
+              // Description
+              if (work.description != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  work.description!,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                  ),
+                ),
+              ],
+
+              const SizedBox(height: 8),
+
+              // Progress bar
+              if (work.progress > 0 || work.isActive)
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: work.progress,
+                    minHeight: 4,
+                    backgroundColor: theme.colorScheme.surfaceContainerHigh,
+                  ),
+                ),
+
+              const SizedBox(height: 6),
+
+              // Bottom row: task count + time
+              Row(
+                children: [
+                  if (work.taskCount != null) ...[
+                    Icon(Icons.task_alt,
+                        size: 14,
+                        color: theme.colorScheme.onSurface
+                            .withValues(alpha: 0.5)),
+                    const SizedBox(width: 4),
+                    Text(
+                      '${work.completedTaskCount ?? 0}/${work.taskCount}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurface
+                            .withValues(alpha: 0.5),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                  ],
+                  Text(
+                    formatRelativeTime(work.createdAt),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface
+                          .withValues(alpha: 0.4),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final WorkStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    Color color;
+    String label;
+    switch (status) {
+      case WorkStatus.pending:
+        color = Colors.grey;
+        label = 'Pending';
+      case WorkStatus.inProgress:
+        color = Colors.blue;
+        label = 'In Progress';
+      case WorkStatus.completed:
+        color = Colors.green;
+        label = 'Completed';
+      case WorkStatus.failed:
+        color = theme.colorScheme.error;
+        label = 'Failed';
+      case WorkStatus.cancelled:
+        color = Colors.orange;
+        label = 'Cancelled';
+      case WorkStatus.paused:
+        color = Colors.amber;
+        label = 'Paused';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+          fontSize: 11,
+        ),
+      ),
+    );
+  }
+}
+
+class _PriorityIndicator extends StatelessWidget {
+  const _PriorityIndicator({required this.priority});
+
+  final Priority priority;
+
+  @override
+  Widget build(BuildContext context) {
+    Color color;
+    switch (priority) {
+      case Priority.urgent:
+        color = Colors.red;
+      case Priority.high:
+        color = Colors.orange;
+      case Priority.normal:
+        color = Colors.blue;
+      case Priority.low:
+        color = Colors.grey;
+    }
+
+    return Container(
+      width: 4,
+      height: 24,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(2),
+      ),
+    );
+  }
+}

--- a/mobile/lib/services/api/knowledge_service.dart
+++ b/mobile/lib/services/api/knowledge_service.dart
@@ -1,0 +1,147 @@
+import 'package:dio/dio.dart';
+
+import '../../models/knowledge.dart';
+import 'api_client.dart';
+
+class KnowledgeService {
+  KnowledgeService(this._client);
+
+  final ApiClient _client;
+
+  // ---- Notes ----
+
+  Future<List<BotNote>> listNotes(
+    String botId, {
+    List<String>? tags,
+    String? search,
+    int? limit,
+    int? offset,
+  }) async {
+    final params = <String, dynamic>{};
+    if (tags != null && tags.isNotEmpty) params['tags'] = tags.join(',');
+    if (search != null) params['search'] = search;
+    if (limit != null) params['limit'] = limit;
+    if (offset != null) params['offset'] = offset;
+
+    final response = await _client.dio.get(
+      '/api/bots/$botId/knowledge/notes',
+      queryParameters: params,
+    );
+    final list = response.data as List<dynamic>;
+    return list.map((e) => BotNote.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<BotNote> getNote(String botId, String noteId) async {
+    final response = await _client.dio.get(
+      '/api/bots/$botId/knowledge/notes/$noteId',
+    );
+    return BotNote.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotNote> createNote(
+    String botId, {
+    required String title,
+    required String content,
+    List<String> tags = const [],
+  }) async {
+    final response = await _client.dio.post(
+      '/api/bots/$botId/knowledge/notes',
+      data: {
+        'title': title,
+        'content': content,
+        'tags': tags,
+      },
+    );
+    return BotNote.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotNote> updateNote(
+    String botId,
+    String noteId, {
+    String? title,
+    String? content,
+    List<String>? tags,
+  }) async {
+    final data = <String, dynamic>{};
+    if (title != null) data['title'] = title;
+    if (content != null) data['content'] = content;
+    if (tags != null) data['tags'] = tags;
+
+    final response = await _client.dio.put(
+      '/api/bots/$botId/knowledge/notes/$noteId',
+      data: data,
+    );
+    return BotNote.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteNote(String botId, String noteId) async {
+    await _client.dio.delete('/api/bots/$botId/knowledge/notes/$noteId');
+  }
+
+  Future<List<String>> getTags(String botId) async {
+    final response = await _client.dio.get(
+      '/api/bots/$botId/knowledge/notes/tags',
+    );
+    return (response.data as List<dynamic>).cast<String>();
+  }
+
+  // ---- Stats ----
+
+  Future<KnowledgeStats> getStats(String botId) async {
+    final response = await _client.dio.get(
+      '/api/bots/$botId/knowledge/stats',
+    );
+    return KnowledgeStats.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  // ---- Search ----
+
+  Future<List<SearchResult>> search(
+    String botId,
+    String query, {
+    bool includeNotes = true,
+    bool includeDocs = true,
+    int limit = 20,
+  }) async {
+    final response = await _client.dio.post(
+      '/api/bots/$botId/knowledge/search',
+      data: {
+        'query': query,
+        'include_notes': includeNotes,
+        'include_documents': includeDocs,
+        'limit': limit,
+      },
+    );
+    final list = response.data as List<dynamic>;
+    return list.map((e) => SearchResult.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  // ---- Documents ----
+
+  Future<List<KnowledgeDocument>> listDocuments(String botId) async {
+    final response = await _client.dio.get('/api/bots/$botId/documents');
+    final list = response.data as List<dynamic>;
+    return list
+        .map((e) => KnowledgeDocument.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Map<String, dynamic>> uploadDocument(
+    String botId,
+    String filePath,
+    String fileName,
+  ) async {
+    final formData = FormData.fromMap({
+      'file': await MultipartFile.fromFile(filePath, filename: fileName),
+    });
+    final response = await _client.dio.post(
+      '/api/bots/$botId/documents',
+      data: formData,
+    );
+    return response.data as Map<String, dynamic>;
+  }
+
+  Future<void> deleteDocument(String botId, String docId) async {
+    await _client.dio.delete('/api/bots/$botId/documents/$docId');
+  }
+}

--- a/mobile/lib/services/api/work_service.dart
+++ b/mobile/lib/services/api/work_service.dart
@@ -1,0 +1,348 @@
+import '../../models/work.dart';
+import 'api_client.dart';
+
+class WorkService {
+  WorkService(this._client);
+
+  final ApiClient _client;
+
+  // ---- Work CRUD ----
+
+  Future<List<BotWork>> listWork(
+    String botId, {
+    String? status,
+    int? limit,
+  }) async {
+    final params = <String, dynamic>{};
+    if (status != null) params['status'] = status;
+    if (limit != null) params['limit'] = limit;
+
+    final response = await _client.dio.get(
+      '/api/bots/$botId/work',
+      queryParameters: params,
+    );
+    final list = response.data as List<dynamic>;
+    return list.map((e) => BotWork.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<List<BotWork>> getActiveWork(String botId) async {
+    final response = await _client.dio.get('/api/bots/$botId/work/active');
+    final list = response.data as List<dynamic>;
+    return list.map((e) => BotWork.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<BotWork> getWork(String botId, String workId) async {
+    final response = await _client.dio.get('/api/bots/$botId/work/$workId');
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotWork> createWork(
+    String botId, {
+    required String title,
+    String? description,
+    String? goal,
+    String? chatId,
+    String? priority,
+    String? dueAt,
+    List<String>? tags,
+  }) async {
+    final data = <String, dynamic>{
+      'title': title,
+    };
+    if (description != null) data['description'] = description;
+    if (goal != null) data['goal'] = goal;
+    if (chatId != null) data['chatId'] = chatId;
+    if (priority != null) data['priority'] = priority;
+    if (dueAt != null) data['dueAt'] = dueAt;
+    if (tags != null) data['tags'] = tags;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/work',
+      data: data,
+    );
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotWork> updateWork(
+    String botId,
+    String workId, {
+    String? title,
+    String? description,
+    String? goal,
+    String? status,
+    String? priority,
+    double? progress,
+    String? dueAt,
+    List<String>? tags,
+  }) async {
+    final data = <String, dynamic>{};
+    if (title != null) data['title'] = title;
+    if (description != null) data['description'] = description;
+    if (goal != null) data['goal'] = goal;
+    if (status != null) data['status'] = status;
+    if (priority != null) data['priority'] = priority;
+    if (progress != null) data['progress'] = progress;
+    if (dueAt != null) data['dueAt'] = dueAt;
+    if (tags != null) data['tags'] = tags;
+
+    final response = await _client.dio.patch(
+      '/api/bots/$botId/work/$workId',
+      data: data,
+    );
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteWork(String botId, String workId) async {
+    await _client.dio.delete('/api/bots/$botId/work/$workId');
+  }
+
+  // ---- Work Actions ----
+
+  Future<BotWork> startWork(String botId, String workId) async {
+    final response = await _client.dio.post('/api/bots/$botId/work/$workId/start');
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotWork> completeWork(String botId, String workId, {String? result}) async {
+    final params = <String, dynamic>{};
+    if (result != null) params['result'] = result;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/work/$workId/complete',
+      queryParameters: params,
+    );
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotWork> failWork(String botId, String workId, {String? error}) async {
+    final params = <String, dynamic>{};
+    if (error != null) params['error'] = error;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/work/$workId/fail',
+      queryParameters: params,
+    );
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotWork> cancelWork(String botId, String workId) async {
+    final response = await _client.dio.post('/api/bots/$botId/work/$workId/cancel');
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  // ---- Tasks ----
+
+  Future<List<WorkTask>> listTasks(String botId, String workId) async {
+    final response = await _client.dio.get('/api/bots/$botId/work/$workId/tasks');
+    final list = response.data as List<dynamic>;
+    return list.map((e) => WorkTask.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<WorkTask> createTask(
+    String botId,
+    String workId, {
+    required String title,
+    String? description,
+    String? action,
+    int? order,
+    List<String>? dependsOn,
+    String? priority,
+  }) async {
+    final data = <String, dynamic>{
+      'title': title,
+    };
+    if (description != null) data['description'] = description;
+    if (action != null) data['action'] = action;
+    if (order != null) data['order'] = order;
+    if (dependsOn != null) data['dependsOn'] = dependsOn;
+    if (priority != null) data['priority'] = priority;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/work/$workId/tasks',
+      data: data,
+    );
+    return WorkTask.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<WorkTask> updateTask(
+    String botId,
+    String taskId, {
+    String? title,
+    String? description,
+    String? status,
+    String? priority,
+  }) async {
+    final data = <String, dynamic>{};
+    if (title != null) data['title'] = title;
+    if (description != null) data['description'] = description;
+    if (status != null) data['status'] = status;
+    if (priority != null) data['priority'] = priority;
+
+    final response = await _client.dio.patch(
+      '/api/bots/$botId/tasks/$taskId',
+      data: data,
+    );
+    return WorkTask.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteTask(String botId, String taskId) async {
+    await _client.dio.delete('/api/bots/$botId/tasks/$taskId');
+  }
+
+  Future<WorkTask> startTask(String botId, String taskId) async {
+    final response = await _client.dio.post('/api/bots/$botId/tasks/$taskId/start');
+    return WorkTask.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<WorkTask> completeTask(String botId, String taskId, {String? result}) async {
+    final params = <String, dynamic>{};
+    if (result != null) params['result'] = result;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/tasks/$taskId/complete',
+      queryParameters: params,
+    );
+    return WorkTask.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<WorkTask> failTask(String botId, String taskId, {String? error}) async {
+    final params = <String, dynamic>{};
+    if (error != null) params['error'] = error;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/tasks/$taskId/fail',
+      queryParameters: params,
+    );
+    return WorkTask.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  // ---- Jobs ----
+
+  Future<List<Job>> listJobsForTask(String botId, String taskId) async {
+    final response = await _client.dio.get('/api/bots/$botId/tasks/$taskId/jobs');
+    final list = response.data as List<dynamic>;
+    return list.map((e) => Job.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<List<Job>> listJobsForWork(String botId, String workId) async {
+    final response = await _client.dio.get('/api/bots/$botId/work/$workId/jobs');
+    final list = response.data as List<dynamic>;
+    return list.map((e) => Job.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<Job> getJob(String botId, String jobId) async {
+    final response = await _client.dio.get('/api/bots/$botId/jobs/$jobId');
+    return Job.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  // ---- Todos ----
+
+  Future<List<Todo>> listTodos(
+    String botId, {
+    String? status,
+    int? limit,
+  }) async {
+    final params = <String, dynamic>{};
+    if (status != null) params['status'] = status;
+    if (limit != null) params['limit'] = limit;
+
+    final response = await _client.dio.get(
+      '/api/bots/$botId/todos',
+      queryParameters: params,
+    );
+    final list = response.data as List<dynamic>;
+    return list.map((e) => Todo.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<List<Todo>> getOpenTodos(String botId) async {
+    final response = await _client.dio.get('/api/bots/$botId/todos/open');
+    final list = response.data as List<dynamic>;
+    return list.map((e) => Todo.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<Todo> createTodo(
+    String botId, {
+    required String title,
+    String? notes,
+    String? chatId,
+    String? priority,
+    String? remindAt,
+    List<String>? tags,
+  }) async {
+    final data = <String, dynamic>{
+      'title': title,
+    };
+    if (notes != null) data['notes'] = notes;
+    if (chatId != null) data['chatId'] = chatId;
+    if (priority != null) data['priority'] = priority;
+    if (remindAt != null) data['remindAt'] = remindAt;
+    if (tags != null) data['tags'] = tags;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/todos',
+      data: data,
+    );
+    return Todo.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<Todo> updateTodo(
+    String botId,
+    String todoId, {
+    String? title,
+    String? notes,
+    String? status,
+    String? priority,
+    String? remindAt,
+    List<String>? tags,
+  }) async {
+    final data = <String, dynamic>{};
+    if (title != null) data['title'] = title;
+    if (notes != null) data['notes'] = notes;
+    if (status != null) data['status'] = status;
+    if (priority != null) data['priority'] = priority;
+    if (remindAt != null) data['remindAt'] = remindAt;
+    if (tags != null) data['tags'] = tags;
+
+    final response = await _client.dio.patch(
+      '/api/bots/$botId/todos/$todoId',
+      data: data,
+    );
+    return Todo.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteTodo(String botId, String todoId) async {
+    await _client.dio.delete('/api/bots/$botId/todos/$todoId');
+  }
+
+  Future<Todo> completeTodo(String botId, String todoId) async {
+    final response = await _client.dio.post('/api/bots/$botId/todos/$todoId/done');
+    return Todo.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<Todo> dismissTodo(String botId, String todoId) async {
+    final response = await _client.dio.post('/api/bots/$botId/todos/$todoId/dismiss');
+    return Todo.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<BotWork> convertTodoToWork(
+    String botId,
+    String todoId, {
+    bool toWork = true,
+    String? workTitle,
+    String? workDescription,
+    String? priority,
+  }) async {
+    final data = <String, dynamic>{
+      'toWork': toWork,
+    };
+    if (workTitle != null) data['workTitle'] = workTitle;
+    if (workDescription != null) data['workDescription'] = workDescription;
+    if (priority != null) data['priority'] = priority;
+
+    final response = await _client.dio.post(
+      '/api/bots/$botId/todos/$todoId/convert',
+      data: data,
+    );
+    return BotWork.fromJson(response.data as Map<String, dynamic>);
+  }
+}

--- a/mobile/lib/services/notifications/background_service.dart
+++ b/mobile/lib/services/notifications/background_service.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../websocket/websocket_service.dart';
+import 'notification_service.dart';
+
+/// Manages a background WebSocket connection for push-style notifications.
+///
+/// When the app is backgrounded, this service keeps the WS alive and
+/// triggers local notifications for incoming events.
+class BackgroundNotificationService {
+  BackgroundNotificationService._();
+
+  static final BackgroundNotificationService instance =
+      BackgroundNotificationService._();
+
+  StreamSubscription<dynamic>? _eventSub;
+  WebSocketService? _ws;
+  bool _isActive = false;
+  int _notificationId = 1000;
+
+  static const _enabledKey = 'bg_notifications_enabled';
+  static const _messagesEnabledKey = 'notify_messages';
+  static const _approvalsEnabledKey = 'notify_approvals';
+  static const _workEnabledKey = 'notify_work';
+
+  /// Start listening to WebSocket events for background notifications.
+  Future<void> start(WebSocketService ws) async {
+    if (_isActive) return;
+    _ws = ws;
+    _isActive = true;
+
+    _eventSub = ws.events.listen(_handleEvent);
+  }
+
+  /// Stop background notification listening.
+  void stop() {
+    _eventSub?.cancel();
+    _eventSub = null;
+    _isActive = false;
+  }
+
+  bool get isActive => _isActive;
+
+  void _handleEvent(dynamic event) async {
+    // Only notify when we have the payload and event type
+    if (event is! Map<String, dynamic>) return;
+
+    final type = event['type'] as String?;
+    final payload = event['payload'] as Map<String, dynamic>?;
+
+    if (type == null || payload == null) return;
+
+    final prefs = await SharedPreferences.getInstance();
+
+    switch (type) {
+      case 'message':
+        if (prefs.getBool(_messagesEnabledKey) ?? true) {
+          final content = payload['content'] as String? ?? '';
+          final botName = payload['botName'] as String? ?? 'Bot';
+          if (content.isNotEmpty) {
+            await notificationService.showMessage(
+              id: _notificationId++,
+              botName: botName,
+              message: content.length > 100
+                  ? '${content.substring(0, 100)}...'
+                  : content,
+              chatRoute: payload['chatRoute'] as String?,
+            );
+          }
+        }
+
+      case 'approval_needed':
+        if (prefs.getBool(_approvalsEnabledKey) ?? true) {
+          final tool = payload['tool'] as String? ?? 'Unknown';
+          await notificationService.showMessage(
+            id: _notificationId++,
+            botName: 'Approval Required',
+            message: 'Bot wants to use: $tool',
+          );
+        }
+
+      case 'job_update':
+        if (prefs.getBool(_workEnabledKey) ?? true) {
+          final status = payload['status'] as String? ?? '';
+          final title = payload['title'] as String? ?? 'Work';
+          await notificationService.showWorkUpdate(
+            id: _notificationId++,
+            title: 'Work Update',
+            body: '$title: $status',
+          );
+        }
+
+      case 'scheduled_notification':
+        await notificationService.showReminder(
+          id: _notificationId++,
+          title: payload['title'] as String? ?? 'Reminder',
+          body: payload['body'] as String? ?? '',
+          route: payload['route'] as String?,
+        );
+    }
+  }
+
+  // ---- Preference helpers ----
+
+  static Future<bool> isEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_enabledKey) ?? false;
+  }
+
+  static Future<void> setEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+  }
+
+  static Future<bool> messagesEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_messagesEnabledKey) ?? true;
+  }
+
+  static Future<void> setMessagesEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_messagesEnabledKey, value);
+  }
+
+  static Future<bool> approvalsEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_approvalsEnabledKey) ?? true;
+  }
+
+  static Future<void> setApprovalsEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_approvalsEnabledKey, value);
+  }
+
+  static Future<bool> workEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_workEnabledKey) ?? true;
+  }
+
+  static Future<void> setWorkEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_workEnabledKey, value);
+  }
+}
+
+/// Convenience global accessor.
+final backgroundNotificationService = BackgroundNotificationService.instance;

--- a/mobile/lib/services/notifications/background_service.dart
+++ b/mobile/lib/services/notifications/background_service.dart
@@ -16,7 +16,6 @@ class BackgroundNotificationService {
       BackgroundNotificationService._();
 
   StreamSubscription<dynamic>? _eventSub;
-  WebSocketService? _ws;
   bool _isActive = false;
   int _notificationId = 1000;
 
@@ -28,7 +27,6 @@ class BackgroundNotificationService {
   /// Start listening to WebSocket events for background notifications.
   Future<void> start(WebSocketService ws) async {
     if (_isActive) return;
-    _ws = ws;
     _isActive = true;
 
     _eventSub = ws.events.listen(_handleEvent);

--- a/mobile/lib/services/notifications/notification_service.dart
+++ b/mobile/lib/services/notifications/notification_service.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:go_router/go_router.dart';
 

--- a/mobile/lib/services/notifications/notification_service.dart
+++ b/mobile/lib/services/notifications/notification_service.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:go_router/go_router.dart';
+
+/// Manages local notifications on Android/iOS.
+class NotificationService {
+  NotificationService._();
+
+  static final NotificationService instance = NotificationService._();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  GoRouter? _router;
+  bool _initialized = false;
+
+  /// Android notification channel IDs.
+  static const _messagesChannelId = 'cachibot_messages';
+  static const _workChannelId = 'cachibot_work';
+  static const _remindersChannelId = 'cachibot_reminders';
+
+  /// Initialize the notification plugin and create channels.
+  Future<void> init({GoRouter? router}) async {
+    if (_initialized) return;
+    _router = router;
+
+    const androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+
+    await _plugin.initialize(
+      const InitializationSettings(
+        android: androidSettings,
+        iOS: iosSettings,
+      ),
+      onDidReceiveNotificationResponse: _onNotificationTap,
+    );
+
+    // Create Android channels
+    if (Platform.isAndroid) {
+      final androidPlugin =
+          _plugin.resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
+
+      await androidPlugin?.createNotificationChannel(
+        const AndroidNotificationChannel(
+          _messagesChannelId,
+          'Messages',
+          description: 'New messages from bots',
+          importance: Importance.high,
+        ),
+      );
+      await androidPlugin?.createNotificationChannel(
+        const AndroidNotificationChannel(
+          _workChannelId,
+          'Work Updates',
+          description: 'Work and task status changes',
+          importance: Importance.defaultImportance,
+        ),
+      );
+      await androidPlugin?.createNotificationChannel(
+        const AndroidNotificationChannel(
+          _remindersChannelId,
+          'Reminders',
+          description: 'Scheduled reminders',
+          importance: Importance.high,
+        ),
+      );
+    }
+
+    _initialized = true;
+  }
+
+  /// Request notification permission (iOS/Android 13+).
+  Future<bool> requestPermission() async {
+    if (Platform.isAndroid) {
+      final androidPlugin =
+          _plugin.resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
+      return await androidPlugin?.requestNotificationsPermission() ?? false;
+    }
+
+    if (Platform.isIOS) {
+      final iosPlugin =
+          _plugin.resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>();
+      return await iosPlugin?.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+          ) ??
+          false;
+    }
+
+    return false;
+  }
+
+  /// Show a message notification.
+  Future<void> showMessage({
+    required int id,
+    required String botName,
+    required String message,
+    String? chatRoute,
+  }) async {
+    await _show(
+      id: id,
+      title: botName,
+      body: message,
+      channelId: _messagesChannelId,
+      channelName: 'Messages',
+      payload: chatRoute,
+    );
+  }
+
+  /// Show a work update notification.
+  Future<void> showWorkUpdate({
+    required int id,
+    required String title,
+    required String body,
+    String? workRoute,
+  }) async {
+    await _show(
+      id: id,
+      title: title,
+      body: body,
+      channelId: _workChannelId,
+      channelName: 'Work Updates',
+      payload: workRoute,
+    );
+  }
+
+  /// Show a reminder notification.
+  Future<void> showReminder({
+    required int id,
+    required String title,
+    required String body,
+    String? route,
+  }) async {
+    await _show(
+      id: id,
+      title: title,
+      body: body,
+      channelId: _remindersChannelId,
+      channelName: 'Reminders',
+      payload: route,
+    );
+  }
+
+  Future<void> _show({
+    required int id,
+    required String title,
+    required String body,
+    required String channelId,
+    required String channelName,
+    String? payload,
+  }) async {
+    await _plugin.show(
+      id,
+      title,
+      body,
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          channelId,
+          channelName,
+          importance: Importance.high,
+          priority: Priority.high,
+        ),
+        iOS: const DarwinNotificationDetails(
+          presentAlert: true,
+          presentBadge: true,
+          presentSound: true,
+        ),
+      ),
+      payload: payload,
+    );
+  }
+
+  void _onNotificationTap(NotificationResponse response) {
+    final route = response.payload;
+    if (route != null && route.isNotEmpty && _router != null) {
+      _router!.go(route);
+    }
+  }
+
+  /// Cancel a specific notification.
+  Future<void> cancel(int id) => _plugin.cancel(id);
+
+  /// Cancel all notifications.
+  Future<void> cancelAll() => _plugin.cancelAll();
+}
+
+/// Convenience global accessor.
+final notificationService = NotificationService.instance;

--- a/mobile/lib/services/notifications/ntfy_service.dart
+++ b/mobile/lib/services/notifications/ntfy_service.dart
@@ -1,0 +1,139 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'notification_service.dart';
+
+/// Self-hosted ntfy integration for push notifications when the WebSocket
+/// connection is not available (app killed / no background service).
+///
+/// Subscribes to a user-specific ntfy topic via Server-Sent Events (SSE)
+/// and delivers local notifications.
+class NtfyService {
+  NtfyService._();
+
+  static final NtfyService instance = NtfyService._();
+
+  static const _serverUrlKey = 'ntfy_server_url';
+  static const _topicKey = 'ntfy_topic';
+
+  final Dio _dio = Dio();
+  StreamSubscription<dynamic>? _sseSub;
+  bool _isListening = false;
+  int _notificationId = 2000;
+
+  bool get isListening => _isListening;
+
+  /// Start listening to the configured ntfy topic.
+  Future<bool> start({String? userId}) async {
+    if (_isListening) return true;
+
+    final prefs = await SharedPreferences.getInstance();
+    final serverUrl = prefs.getString(_serverUrlKey);
+    if (serverUrl == null || serverUrl.isEmpty) return false;
+
+    final topic = prefs.getString(_topicKey) ?? 'cachibot-${userId ?? 'default'}';
+
+    try {
+      final response = await _dio.get<ResponseBody>(
+        '$serverUrl/$topic/sse',
+        options: Options(
+          responseType: ResponseType.stream,
+          headers: {'Accept': 'text/event-stream'},
+        ),
+      );
+
+      _isListening = true;
+
+      _sseSub = response.data?.stream
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen(
+        (line) {
+          if (line.startsWith('data: ')) {
+            _handleData(line.substring(6));
+          }
+        },
+        onError: (_) {
+          _isListening = false;
+        },
+        onDone: () {
+          _isListening = false;
+        },
+        cancelOnError: false,
+      );
+
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Stop listening.
+  void stop() {
+    _sseSub?.cancel();
+    _sseSub = null;
+    _isListening = false;
+  }
+
+  void _handleData(String data) async {
+    try {
+      final json = jsonDecode(data) as Map<String, dynamic>;
+      final title = json['title'] as String? ?? 'CachiBot';
+      final message = json['message'] as String? ?? '';
+      final tags = (json['tags'] as List<dynamic>?)?.cast<String>() ?? [];
+
+      if (message.isEmpty) return;
+
+      // Route notifications based on tags
+      if (tags.contains('message')) {
+        await notificationService.showMessage(
+          id: _notificationId++,
+          botName: title,
+          message: message,
+        );
+      } else if (tags.contains('work')) {
+        await notificationService.showWorkUpdate(
+          id: _notificationId++,
+          title: title,
+          body: message,
+        );
+      } else {
+        await notificationService.showReminder(
+          id: _notificationId++,
+          title: title,
+          body: message,
+        );
+      }
+    } catch (_) {
+      // Malformed SSE data — ignore
+    }
+  }
+
+  // ---- Configuration ----
+
+  static Future<String?> getServerUrl() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_serverUrlKey);
+  }
+
+  static Future<void> setServerUrl(String url) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_serverUrlKey, url);
+  }
+
+  static Future<void> clearServerUrl() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_serverUrlKey);
+  }
+
+  static Future<void> setTopic(String topic) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_topicKey, topic);
+  }
+}
+
+/// Convenience global accessor.
+final ntfyService = NtfyService.instance;

--- a/mobile/lib/services/notifications/ntfy_service.dart
+++ b/mobile/lib/services/notifications/ntfy_service.dart
@@ -47,7 +47,11 @@ class NtfyService {
 
       _isListening = true;
 
-      _sseSub = response.data?.stream
+      final stream = response.data?.stream;
+      if (stream == null) return false;
+
+      _sseSub = stream
+          .cast<List<int>>()
           .transform(utf8.decoder)
           .transform(const LineSplitter())
           .listen(

--- a/mobile/lib/widgets/common/app_shell.dart
+++ b/mobile/lib/widgets/common/app_shell.dart
@@ -10,6 +10,7 @@ class AppShell extends StatelessWidget {
     final location = GoRouterState.of(context).uri.toString();
     if (location.startsWith('/settings')) return 2;
     if (location.startsWith('/chats') || location.startsWith('/chat')) return 1;
+    // /bot/:botId routes stay on Home tab (index 0)
     return 0;
   }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: "direct main"
     description:
@@ -305,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   fixnum:
     dependency: transitive
     description:
@@ -334,6 +350,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.5.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_markdown:
     dependency: "direct main"
     description:
@@ -792,6 +840,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -872,6 +928,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  receive_sharing_intent:
+    dependency: "direct main"
+    description:
+      name: receive_sharing_intent
+      sha256: ec76056e4d258ad708e76d85591d933678625318e411564dcb9059048ca3a593
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   riverpod:
     dependency: transitive
     description:
@@ -1005,6 +1069,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      sha256: c07557664974afa061f221d0d4186935bea4220728ea9446702825e8b988db04
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      sha256: a1935847704e41ee468aad83181ddd2423d0833abe55d769c59afca07adb5114
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  speech_to_text_windows:
+    dependency: transitive
+    description:
+      name: speech_to_text_windows
+      sha256: "2c9846d18253c7bbe059a276297ef9f27e8a2745dead32192525beb208195072"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+beta.8"
   sqlite3:
     dependency: transitive
     description:
@@ -1085,6 +1173,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.9"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   timing:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -44,6 +44,12 @@ dependencies:
   local_auth: ^2.3.0
   mobile_scanner: ^6.0.2
 
+  # Phase 4: Documents, Notifications, Share, Voice
+  file_picker: ^8.0.0
+  flutter_local_notifications: ^19.0.0
+  speech_to_text: ^7.0.0
+  receive_sharing_intent: ^1.8.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "prompture>=1.0.42",
+    "prompture>=1.0.43",
     "tukuy>=0.0.30",
     "typer>=0.12.0",
     "rich>=13.0.0",


### PR DESCRIPTION
The agent was being assembled from scratch in three different places, each with its own flavor of the same environment-resolution-context-building-tool-merging dance. This PR puts that ceremony in one room (`AgentFactory`), then uses the freed-up headroom to ship coding agent streaming on platforms and a big chunk of the mobile app.

### Highlights

- Coding agents (Claude Code, Codex CLI, Gemini CLI) can now be triggered from Telegram and Discord via @mentions with real-time output streamed back through live message editing
- Mobile app gains full knowledge management — notes, search, and a rich editor
- Work tracking and todos are now available on mobile with create, edit, and status workflows
- Push notifications via ntfy deliver messages, approval requests, and reminders when the app is backgrounded
- Android share intent lets you send text, PDFs, and documents directly into CachiBot

<details>
<summary>Technical changes</summary>

- New `AgentFactory` service (`cachibot/services/agent_factory.py`) centralizes the full agent construction pipeline: disabled-capability loading, model override, per-bot environment resolution, tool-config merging, context building, coding-agent instruction injection, and dynamic instruction loading
- `websocket.py` drops ~130 lines of duplicated agent setup — `_resolve_bot_env`, `_inject_coding_agent_instructions`, inline context building, manual `copy.deepcopy` config — and delegates to `build_bot_agent()`
- `message_processor.py` drops ~80 lines of the same duplicated logic, including its own separate environment resolution path that handled endpoint-vs-key driver construction differently from the websocket path
- New `CodingAgentDispatcher` (`cachibot/services/coding_agent_dispatcher.py`) intercepts `@claude`/`@codex`/`@gemini` mentions on platform messages, spawns the CLI as a subprocess in the workspace, streams stdout via periodic live message edits, saves conversation history, and broadcasts to WebSocket clients
- `PlatformManager._handle_message` integrates the dispatcher with `/cancel` and `/stop` support for killing active sessions
- `BasePlatformAdapter` gains `send_and_get_id()` and `edit_message()` abstract methods for live-streaming message updates
- `DiscordAdapter` and `TelegramAdapter` implement `send_and_get_id` and `edit_message` with platform-specific ID handling and message length enforcement
- New `NtfyService` (`cachibot/services/ntfy.py`) provides push notifications via self-hosted ntfy with convenience methods for messages, approval requests, work updates, and reminders
- `CachibotAgent` gains a `platform_metadata` field; `_get_system_prompt` refactored to always append tool list, background jobs section, platform context, and usage guidelines even when `system_prompt_override` is set
- Mobile: new data models (`Knowledge`, `Work`) with full serialization, provider layer (`knowledge_provider`, `work_provider`, `todos_provider`, `tasks_provider`), and API services (`knowledge_service`, `work_service`)
- Mobile: `KnowledgeListScreen`, `KnowledgeSearchScreen`, `NoteEditorScreen` for browsing, searching, and editing notes
- Mobile: `WorkListScreen`, `WorkDetailScreen`, `TodosScreen` for work tracking and todo management
- Mobile: `BotDetailScreen` with tabbed navigation across chats, knowledge, and work per bot
- Mobile: `SettingsScreen` with server URL configuration
- Mobile: notification stack — `NtfyService` (SSE subscription), `NotificationService` (local notifications via flutter_local_notifications), `BackgroundService` (lifecycle-aware polling)
- Mobile: `AndroidManifest.xml` adds share intent filters for `text/*`, `application/pdf`, `text/markdown`, and DOCX mime types

</details>
