### PR TITLE
Add coding agent streaming, mobile app features, and centralize agent construction

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -8,9 +8,10 @@ plugins {
 android {
     namespace = "com.cachibot.cachibot_mobile"
     compileSdk = 36
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -37,6 +38,10 @@ android {
             signingConfig = signingConfigs.getByName("debug")
         }
     }
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }
 
 flutter {

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -19,6 +19,21 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Force consistent JVM target across all subprojects (fixes plugin mismatches)
+subprojects {
+    afterEvaluate {
+        extensions.findByType<com.android.build.gradle.BaseExtension>()?.compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
+        tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+            compilerOptions {
+                jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            }
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -19,8 +19,9 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
-// Force consistent JVM target across all subprojects (fixes plugin mismatches)
+// Force consistent JVM target on plugin subprojects (fixes plugin mismatches)
 subprojects {
+    if (project.name == "app") return@subprojects
     afterEvaluate {
         extensions.findByType<com.android.build.gradle.BaseExtension>()?.compileOptions {
             sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
The agent was being assembled from scratch in three different places, each with its own flavor of the same environment-resolution-context-building-tool-merging dance. This PR puts that ceremony in one room (`AgentFactory`), then uses the freed-up headroom to ship coding agent streaming on platforms and a big chunk of the mobile app.

### Highlights

- Coding agents (Claude Code, Codex CLI, Gemini CLI) can now be triggered from Telegram and Discord via @mentions with real-time output streamed back through live message editing
- Mobile app gains full knowledge management — notes, search, and a rich editor
- Work tracking and todos are now available on mobile with create, edit, and status workflows
- Push notifications via ntfy deliver messages, approval requests, and reminders when the app is backgrounded
- Android share intent lets you send text, PDFs, and documents directly into CachiBot

<details>
<summary>Technical changes</summary>

- New `AgentFactory` service (`cachibot/services/agent_factory.py`) centralizes the full agent construction pipeline: disabled-capability loading, model override, per-bot environment resolution, tool-config merging, context building, coding-agent instruction injection, and dynamic instruction loading
- `websocket.py` drops ~130 lines of duplicated agent setup — `_resolve_bot_env`, `_inject_coding_agent_instructions`, inline context building, manual `copy.deepcopy` config — and delegates to `build_bot_agent()`
- `message_processor.py` drops ~80 lines of the same duplicated logic, including its own separate environment resolution path that handled endpoint-vs-key driver construction differently from the websocket path
- New `CodingAgentDispatcher` (`cachibot/services/coding_agent_dispatcher.py`) intercepts `@claude`/`@codex`/`@gemini` mentions on platform messages, spawns the CLI as a subprocess in the workspace, streams stdout via periodic live message edits, saves conversation history, and broadcasts to WebSocket clients
- `PlatformManager._handle_message` integrates the dispatcher with `/cancel` and `/stop` support for killing active sessions
- `BasePlatformAdapter` gains `send_and_get_id()` and `edit_message()` abstract methods for live-streaming message updates
- `DiscordAdapter` and `TelegramAdapter` implement `send_and_get_id` and `edit_message` with platform-specific ID handling and message length enforcement
- New `NtfyService` (`cachibot/services/ntfy.py`) provides push notifications via self-hosted ntfy with convenience methods for messages, approval requests, work updates, and reminders
- `CachibotAgent` gains a `platform_metadata` field; `_get_system_prompt` refactored to always append tool list, background jobs section, platform context, and usage guidelines even when `system_prompt_override` is set
- Mobile: new data models (`Knowledge`, `Work`) with full serialization, provider layer (`knowledge_provider`, `work_provider`, `todos_provider`, `tasks_provider`), and API services (`knowledge_service`, `work_service`)
- Mobile: `KnowledgeListScreen`, `KnowledgeSearchScreen`, `NoteEditorScreen` for browsing, searching, and editing notes
- Mobile: `WorkListScreen`, `WorkDetailScreen`, `TodosScreen` for work tracking and todo management
- Mobile: `BotDetailScreen` with tabbed navigation across chats, knowledge, and work per bot
- Mobile: `SettingsScreen` with server URL configuration
- Mobile: notification stack — `NtfyService` (SSE subscription), `NotificationService` (local notifications via flutter_local_notifications), `BackgroundService` (lifecycle-aware polling)
- Mobile: `AndroidManifest.xml` adds share intent filters for `text/*`, `application/pdf`, `text/markdown`, and DOCX mime types

</details>
